### PR TITLE
[PERF]: Add cursor-based pagination to list APIs

### DIFF
--- a/src/main/kotlin/com/quri/management/QuriServerConfig.kt
+++ b/src/main/kotlin/com/quri/management/QuriServerConfig.kt
@@ -70,7 +70,7 @@ class QuriServerConfig {
     @Bean
     fun smithyServer(
         quriService: Quri,
-        @Value("\${smithy.server.port}") port: Int): Server {
+        @Value($$"${smithy.server.port}") port: Int): Server {
         val server = NettyServerProvider()
             .serverBuilder()
             .endpoints(URI.create("http://localhost:$port"))

--- a/src/main/kotlin/com/quri/management/db/mongo/MongoExtensions.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/MongoExtensions.kt
@@ -1,0 +1,46 @@
+package com.quri.management.db.mongo
+
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import kotlinx.coroutines.flow.toList
+import org.bson.conversions.Bson
+import org.bson.types.ObjectId
+
+/**
+ * Paginates a MongoDB collection using cursor-based pagination.
+ *
+ * Fetches [pageSize] + 1 documents to determine if more pages exist without
+ * an additional count query. Returns the page of results and an opaque
+ * [nextToken] string to be passed by the client on the next request.
+ *
+ * @param collection the MongoDB collection to paginate
+ * @param pageSize maximum number of results to return
+ * @param nextToken opaque cursor from the previous response, null for the first page
+ * @param filter optional additional filter to apply alongside the cursor
+ * @param idExtractor function to extract the ObjectId from a document, used to generate the next cursor
+ * @return a pair of the page results and the next cursor token, or null if this is the last page
+ */
+suspend fun <T : Any> paginate(
+    collection: MongoCollection<T>,
+    pageSize: Int,
+    nextToken: String?,
+    filter: Bson = Filters.empty(),
+    idExtractor: (T) -> ObjectId
+): Pair<List<T>, String?> {
+    val cursorFilter = nextToken
+        ?.let { Filters.and(filter, Filters.gt("_id", ObjectId(it))) }
+        ?: filter
+
+    val results = collection
+        .find(cursorFilter)
+        .sort(Sorts.ascending("_id"))
+        .limit(pageSize + 1)
+        .toList()
+
+    val hasMore = results.size > pageSize
+    val page = if (hasMore) results.dropLast(1) else results
+    val newToken = if (hasMore) idExtractor(page.last()).toHexString() else null
+
+    return page to newToken
+}

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
@@ -6,11 +6,11 @@ import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.quri.management.db.mongo.MongoSchema.Collections.BILLS
 import com.quri.management.db.mongo.documents.BillDocument
 import com.quri.management.db.mongo.documents.MonetaryAmountDocument
+import com.quri.management.db.mongo.paginate
 import com.quri.server.model.Bill
 import com.quri.server.model.CreateBillInput
 import com.quri.server.model.MonetaryAmount
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.toList
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
 
@@ -45,7 +45,7 @@ class BillCollection(
      * Persists a new bill document and returns it alongside its generated ID.
      *
      * @param input the [CreateBillInput] containing total and balance
-     * @return the persisted [Bill] with [Bill.billId] populated, or `null` if
+     * @return the persisted [Bill] with [Bill.id] populated, or `null` if
      * the insert did not return a generated ID
      */
     suspend fun create(input: CreateBillInput): Bill? {
@@ -56,20 +56,23 @@ class BillCollection(
         val result = collection.insertOne(doc)
         val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
         return doc.toSmithyModel().toBuilder()
-            .billId(generatedId)
+            .id(generatedId)
             .createdAt(doc.createdAt)
             .updatedAt(doc.updatedAt)
             .build()
     }
 
     /**
-     * Returns all bills in the collection.
+     * Returns a paginated list of all bills in the collection in ascending order by ID.
      *
-     * @return list of all [Bill] documents mapped to Smithy models
+     * @param pageSize is the maximum results per page
+     * @param nextToken is the bookmarked ID the next paginated list starts from
+     *
+     * @return list of all [Bill] documents mapped to Smithy models and nullable pagination token
      */
-    suspend fun findAll(): List<Bill> {
-        return collection.find().toList().map { it.toSmithyModel() }
-    }
+    suspend fun listAll(pageSize: Int, nextToken: String?): Pair<List<Bill>, String?> =
+        paginate(collection, pageSize, nextToken) { it.id }
+            .let { (docs, token) -> docs.map { it.toSmithyModel()} to token }
 
     /**
      * Deletes a bill by its [ObjectId]
@@ -84,7 +87,7 @@ class BillCollection(
 
     private fun BillDocument.toSmithyModel(): Bill =
         Bill.builder()
-            .billId(id.toString())
+            .id(id.toString())
             .total(
                 MonetaryAmount.builder()
                     .amount(total.amount)
@@ -97,5 +100,7 @@ class BillCollection(
                     .currencyCode(balance.currencyCode)
                     .build()
             )
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
             .build()
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -5,13 +5,12 @@ import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.quri.management.db.mongo.MongoSchema.Collections.PROFILES
 import com.quri.management.db.mongo.documents.ProfileDocument
+import com.quri.management.db.mongo.paginate
 import com.quri.server.model.CreateProfileInput
 import com.quri.server.model.Profile
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.toList
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
-import java.time.Instant
 
 /**
  * Data access layer for the profiles collection in MongoDB.
@@ -44,7 +43,7 @@ class ProfileCollection(
      * Persists a new profile document and returns it alongside its generated ID.
      *
      * @param input the [CreateProfileInput] containing personal user info
-     * @return the persisted [Profile] with [Profile.profileId] populated, or `null` if
+     * @return the persisted [Profile] with [Profile.id] populated, or `null` if
      * the insert did not return a generated ID
      */
     suspend fun create(input: CreateProfileInput): Profile? {
@@ -58,20 +57,23 @@ class ProfileCollection(
         val result = collection.insertOne(doc)
         val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
         return doc.toSmithyModel().toBuilder()
-            .profileId(generatedId)
+            .id(generatedId)
             .createdAt(doc.createdAt)
             .updatedAt(doc.updatedAt)
             .build()
     }
 
     /**
-     * Returns all profiles in the collection.
+     * Returns a paginated list of all profiles in the collection in ascending order by ID.
      *
-     * @return list of all [Profile] documents mapped to Smithy models
+     * @param pageSize is the maximum results per page
+     * @param nextToken is the bookmarked ID the next paginated list starts from
+     *
+     * @return pair of all [Profile] documents mapped to Smithy models and nullable pagination token
      */
-    suspend fun listAll(): List<Profile> {
-        return collection.find().toList().map { it.toSmithyModel() }
-    }
+    suspend fun listAll(pageSize: Int, nextToken: String?): Pair<List<Profile>, String?> =
+        paginate(collection, pageSize, nextToken) { it.id }
+            .let { (docs, token) -> docs.map { it.toSmithyModel()} to token }
 
     /**
      * Deletes a profile by its [ObjectId].
@@ -86,11 +88,13 @@ class ProfileCollection(
 
     private fun ProfileDocument.toSmithyModel(): Profile =
         Profile.builder()
-            .profileId(id.toString())
+            .id(id.toString())
             .username(username)
             .firstName(firstName)
             .lastName(lastName)
             .email(email)
             .phoneNumber(phoneNumber)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
             .build()
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
@@ -19,7 +19,7 @@ data class ProfileDocument(
     val firstName: String,
     val lastName: String,
     val email: String,
-    val phoneNumber: String,
+    val phoneNumber: String?,
     val createdAt: Instant = Instant.now(),
     val updatedAt: Instant = Instant.now()
 )

--- a/src/main/kotlin/com/quri/management/handlers/bills/ListBills.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/ListBills.kt
@@ -21,12 +21,16 @@ class ListBills(
     private val billService: BillService
 ): ListBillsOperation {
     override fun listBills(input: ListBillsInput, context: RequestContext?): ListBillsOutput {
-        val billsFound = runBlocking {
-            billService.listBills()
+        val (bills, newToken) = runBlocking {
+            billService.listBills(
+                pageSize = input.maxResults ?: 20,
+                nextToken = input.nextToken
+            )
         }
 
         return ListBillsOutput.builder()
-            .bills(billsFound)
+            .bills(bills)
+            .nextToken(newToken)
             .build()
     }
 }

--- a/src/main/kotlin/com/quri/management/handlers/profiles/ListProfiles.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/ListProfiles.kt
@@ -21,12 +21,16 @@ class ListProfiles(
     private val profilesService: ProfileService
 ): ListProfilesOperation {
     override fun listProfiles(input: ListProfilesInput, context: RequestContext?): ListProfilesOutput {
-        val profilesFound = runBlocking {
-            profilesService.listProfiles()
+        val (profiles, newToken) = runBlocking {
+            profilesService.listProfiles(
+                pageSize = input.maxResults ?: 20,
+                nextToken = input.nextToken
+            )
         }
 
         return ListProfilesOutput.builder()
-            .profiles(profilesFound)
+            .profiles(profiles)
+            .nextToken(newToken)
             .build()
     }
 }

--- a/src/main/kotlin/com/quri/management/services/BillService.kt
+++ b/src/main/kotlin/com/quri/management/services/BillService.kt
@@ -44,11 +44,12 @@ class BillService(
                 .build()
 
     /**
-     * Returns all bills.
+     * Returns a paginated list of bills.
      *
-     * @return list of all [Bill] records
+     * @return list of all [Bill] records and nullable pagination token
      */
-    suspend fun listBills(): List<Bill> = billCollection.findAll()
+    suspend fun listBills(pageSize: Int, nextToken: String?): Pair<List<Bill>, String?> =
+        billCollection.listAll(pageSize, nextToken)
 
     /**
      * Deletes a bill by its ID.

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -45,11 +45,12 @@ class ProfileService(
                 .build()
 
     /**
-     * Returns all profiles.
+     * Returns a paginated list of profiles.
      *
-     * @return list of all [Profile] records
+     * @return list of all [Profile] records and nullable pagination token
      */
-    suspend fun listProfiles(): List<Profile> = profileCollection.listAll()
+    suspend fun listProfiles(pageSize: Int, nextToken: String?): Pair<List<Profile>, String?> =
+        profileCollection.listAll(pageSize, nextToken)
 
     /**
      * Deletes a profile by its ID.


### PR DESCRIPTION
Follow up on adding linter to Smithy, list APIs required to have pagination by default.

- Added created/updated timestamp to API output
- Extracted `paginated` logic to MongoExtensions file to avoid duplicate code
- Implemented resolution for off-by-one problem where a full page with exact amount of items returns token for empty page
- Minor description updates after model change

---
Tested by making API calls following the pattern for both profiles and bills
```shell
curl -X GET "http://localhost:8080/bills?maxResults=<number-here>&nextToken=<token-here>" | jq .
```