### PR TITLE
[CONFIG] Add logback configuration for local and prod structured logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
 	// Spring - DI container only, no web server
 	implementation("org.springframework.boot:spring-boot-starter")
 
+	// Structured JSON logging for external monitoring tools
+	implementation(libs.logstash.logback.encoder)
+
 	// Smithy server
 	implementation(libs.quri.models)
 	implementation(libs.smithy.java.server.core)
@@ -64,4 +67,13 @@ tasks.withType<Test> {
 
 	// TODO: Enable tests
 	enabled = false
+}
+
+configurations.all {
+	resolutionStrategy.eachDependency {
+		if (requested.group == "com.fasterxml.jackson.core") {
+			useVersion("2.18.6")
+			because("GHSA-72hv-8253-57qq patched in 2.18.6")
+		}
+	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 quri-models-version = "0.1.0"
 mongodb-version = "5.6.4"
 smithy-java-version = "0.0.3"
+logstash-logback-version = "7.4"
 
 [libraries]
 # Smithy server
@@ -13,3 +14,6 @@ smithy-java-server-netty = { module = "software.amazon.smithy.java:server-netty"
 # Database
 mongodb-bson-kotlinx = { module = "org.mongodb:bson-kotlinx", version.ref = "mongodb-version" }
 mongodb-driver-kotlin-coroutine = { module = "org.mongodb:mongodb-driver-kotlin-coroutine", version.ref = "mongodb-version" }
+
+# Logger
+logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback-version" }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=quri-management-service
+spring.profiles.active=local
 smithy.server.port=8080

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- Restores Spring Boot's %highlight, %cyan, and %clr color converters -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- Imports from application.properties -->
+    <springProperty scope="context" name="appName" source="spring.application.name"/>
+
+    <!-- ==========================================
+     CONSOLE — human-readable, for local dev
+     ========================================== -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %clr(%d{HH:mm:ss.SSS}){faint} %highlight(%-5level) %cyan(%-30.30logger{30}) [%X{requestId:-no-request-id}] %msg%n%ex
+            </pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <!-- ==========================================
+         FILE — structured JSON, for aggregators
+         Add logstash-logback-encoder dependency
+         when this appender is activated
+         ========================================== -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${appName}.log</file>
+
+        <!-- Roll daily AND when file hits 10MB — %i required for size-based index -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${appName}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+
+        <!-- JSON encoder — every field queryable -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timeZone>UTC</timeZone>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <level>level</level>
+                <logger>logger</logger>
+                <thread>thread</thread>
+                <message>message</message>
+                <stackTrace>stackTrace</stackTrace>
+
+                <!-- Strip noise -->
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <!-- Async wrapper so file I/O never blocks request threads -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <!-- ==========================================
+         PROFILE ROUTING
+         local -> console only, no file I/O overhead
+         prod/staging -> both, JSON goes to file
+         ========================================== -->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.quri" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod,staging">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+        <logger name="com.quri" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </logger>
+    </springProfile>
+
+    <!-- Suppress noisy third-party frameworks -->
+    <logger name="software.amazon.smithy" level="WARN"/>
+    <logger name="org.springframework"    level="WARN"/>
+    <logger name="org.mongodb.driver"     level="WARN"/>
+
+</configuration>


### PR DESCRIPTION
Added logback configuration for fine control over logging structure in local and prod environments.

Implementations include:
- profile conditions for routing logging based on environment
- structured JSON logging to rolling files
- async logging
- file size restrictions with datetime partitions
- clean, modifiable log pattern

Opens up opportunity for external monitoring tools like ELK, Loki, Grafana, or Splunk for errors and traffic.

> `Appender named [ASYNC_FILE] not referenced. Skipping further processing.` message is expected for local environment, prod environments will structure and save to `logs/` directory where developers can use `jq` to parse and search with ease.

> Logstash has transient errors for releases 7.4 - 9.0, downgrading `com.fasterxml.jackson.core` to resolve vulnerability check.

---
Ref: https://logback.qos.ch/documentation.html