### PR TITLE
[FIX]: fix request body serializtion and add object ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### Postman ###
+.postman
+postman

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
@@ -43,13 +43,15 @@ class BillCollection(dataStoreDatabase: MongoDatabase) {
      * Persists a new bill document and returns it alongside its generated ID.
      *
      * @param input the [CreateBillInput] containing total and balance
+     * @param ownerId the owning entity
      * @return the persisted [Bill] with [Bill.id] populated, or `null` if
      * the insert did not return a generated ID
      */
-    suspend fun create(input: CreateBillInput): Bill? {
+    suspend fun create(input: CreateBillInput, ownerId: String): Bill? {
         val doc = BillDocument(
             total = MonetaryAmountDocument(input.total.amount, input.total.currency),
             balance = MonetaryAmountDocument(input.balance.amount, input.balance.currency),
+            ownerId = ownerId,
         )
         val result = collection.insertOne(doc)
         val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
@@ -101,6 +103,7 @@ class BillCollection(dataStoreDatabase: MongoDatabase) {
                     .currency(balance.currencyCode)
                     .build(),
             )
+            .ownerId(ownerId)
             .createdAt(createdAt)
             .updatedAt(updatedAt)
             .build()

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -43,16 +43,18 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
      * Persists a new profile document and returns it alongside its generated ID.
      *
      * @param input the [CreateProfileInput] containing personal user info
+     * @param ownerId the owning entity
      * @return the persisted [Profile] with [Profile.id] populated, or `null` if
      * the insert did not return a generated ID
      */
-    suspend fun create(input: CreateProfileInput): Profile? {
+    suspend fun create(input: CreateProfileInput, ownerId: String): Profile? {
         val doc = ProfileDocument(
             username = input.username,
             firstName = input.firstName,
             lastName = input.lastName,
             email = input.email,
             phoneNumber = input.phoneNumber,
+            ownerId = ownerId,
         )
         val result = collection.insertOne(doc)
         val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
@@ -99,6 +101,7 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
             .lastName(lastName)
             .email(email)
             .phoneNumber(phoneNumber)
+            .ownerId(ownerId)
             .createdAt(createdAt)
             .updatedAt(updatedAt)
             .build()

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/BillDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/BillDocument.kt
@@ -9,11 +9,13 @@ import java.time.Instant
  *
  * @param total combined total of all items in the bill
  * @param balance remaining amount to be paid
+ * @param ownerId owning authority
  */
 data class BillDocument(
     @BsonId val id: ObjectId = ObjectId(),
     val total: MonetaryAmountDocument,
     val balance: MonetaryAmountDocument,
+    val ownerId: String,
     val createdAt: Instant = Instant.now(),
     val updatedAt: Instant = Instant.now(),
 )

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
@@ -12,6 +12,7 @@ import java.time.Instant
  * @param lastName user's last name
  * @param email user's email address
  * @param phoneNumber user's phone number
+ * @param ownerId owning authority
  */
 data class ProfileDocument(
     @BsonId val id: ObjectId = ObjectId(),
@@ -20,6 +21,7 @@ data class ProfileDocument(
     val lastName: String,
     val email: String,
     val phoneNumber: String?,
+    val ownerId: String,
     val createdAt: Instant = Instant.now(),
     val updatedAt: Instant = Instant.now(),
 )

--- a/src/main/kotlin/com/quri/management/errors/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/quri/management/errors/GlobalExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.server.ServerWebInputException
 
 /**
  * Global exception handler for all controllers across the application.
@@ -41,6 +42,14 @@ class GlobalExceptionHandler {
     fun handleInternalFailure(ex: InternalFailureException): ResponseEntity<ErrorResponse> {
         logger.warn("Internal failure: {}", ex.message)
         return error(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred")
+    }
+
+    // ── Server input exceptions ──────────────────────────────────────────────
+
+    @ExceptionHandler(ServerWebInputException::class)
+    fun handleWebInput(ex: ServerWebInputException): ResponseEntity<ErrorResponse> {
+        logger.warn("Malformed request body: {}", ex.cause?.message)
+        return error(HttpStatus.BAD_REQUEST, "Malformed request body")
     }
 
     // ── Catch-all ─────────────────────────────────────────────────────────────

--- a/src/main/kotlin/com/quri/management/handlers/bills/CreateBill.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/CreateBill.kt
@@ -3,6 +3,8 @@ package com.quri.management.handlers.bills
 import com.quri.client.model.CreateBillInput
 import com.quri.client.model.CreateBillOutput
 import com.quri.management.services.BillService
+import com.quri.management.validators.inputs.bills.CreateBillInputRequest
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,15 +17,25 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/bills")
-class CreateBill(private val billService: BillService) {
+class CreateBill(
+    private val billService: BillService,
+) {
     @PostMapping
-    suspend fun createBill(@RequestBody input: CreateBillInput): CreateBillOutput {
-        val created = billService.createBill(input)
+    suspend fun createBill(
+        @RequestBody request: CreateBillInputRequest,
+        authentication: JwtAuthenticationToken,
+    ): CreateBillOutput {
+        val userId = authentication.token.subject
+
+        val input = CreateBillInput.builder()
+            .total(request.total?.toSmithyModel())
+            .balance(request.balance?.toSmithyModel())
+            .build()
+
+        val created = billService.createBill(input, userId)
 
         return CreateBillOutput.builder()
             .bill(created)
             .build()
     }
-
-    // TODO: Add input validation for [CreateBillInput]
 }

--- a/src/main/kotlin/com/quri/management/handlers/bills/DeleteBill.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/DeleteBill.kt
@@ -18,15 +18,14 @@ import org.springframework.web.bind.annotation.RestController
 class DeleteBill(private val billService: BillService) {
     @DeleteMapping
     suspend fun deleteBill(@PathVariable billId: String): DeleteBillOutput {
-        val input = deleteBillInput(billId)
+        val input = DeleteBillInput.builder()
+            .billId(billId)
+            .build()
+
         val deletedBillId = billService.deleteBill(input)
+
         return DeleteBillOutput.builder()
             .billId(deletedBillId)
             .build()
     }
-
-    private fun deleteBillInput(billId: String): DeleteBillInput =
-        DeleteBillInput.builder()
-            .billId(billId)
-            .build()
 }

--- a/src/main/kotlin/com/quri/management/handlers/bills/GetBill.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/GetBill.kt
@@ -18,16 +18,14 @@ import org.springframework.web.bind.annotation.RestController
 class GetBill(private val billService: BillService) {
     @GetMapping
     suspend fun getBill(@PathVariable billId: String): GetBillOutput {
-        val input = getBillInput(billId)
+        val input = GetBillInput.builder()
+            .billId(billId)
+            .build()
+
         val billFound = billService.getBillFromId(input)
 
         return GetBillOutput.builder()
             .bill(billFound)
             .build()
     }
-
-    private fun getBillInput(billId: String): GetBillInput =
-        GetBillInput.builder()
-            .billId(billId)
-            .build()
 }

--- a/src/main/kotlin/com/quri/management/handlers/bills/ListBills.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/ListBills.kt
@@ -21,7 +21,12 @@ class ListBills(private val billService: BillService) {
         @RequestParam maxResults: Int?,
         @RequestParam nextToken: String?,
     ): ListBillsOutput {
-        val input = listBillsInput(maxResults, nextToken)
+        val pageSize = (maxResults ?: DEFAULT_BILLS_PAGE_SIZE).coerceIn(1, MAX_BILLS_PAGE_SIZE)
+        val input = ListBillsInput.builder()
+            .maxResults(pageSize)
+            .nextToken(nextToken)
+            .build()
+
         val (bills, newToken) = billService.listBills(
             pageSize = input.maxResults,
             nextToken = input.nextToken,
@@ -30,17 +35,6 @@ class ListBills(private val billService: BillService) {
         return ListBillsOutput.builder()
             .bills(bills)
             .nextToken(newToken)
-            .build()
-    }
-
-    private fun listBillsInput(
-        maxResults: Int?,
-        nextToken: String?,
-    ): ListBillsInput {
-        val pageSize = (maxResults ?: DEFAULT_BILLS_PAGE_SIZE).coerceIn(1, MAX_BILLS_PAGE_SIZE)
-        return ListBillsInput.builder()
-            .maxResults(pageSize)
-            .nextToken(nextToken)
             .build()
     }
 

--- a/src/main/kotlin/com/quri/management/handlers/profiles/CreateProfile.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/CreateProfile.kt
@@ -3,6 +3,8 @@ package com.quri.management.handlers.profiles
 import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.CreateProfileOutput
 import com.quri.management.services.ProfileService
+import com.quri.management.validators.inputs.profiles.CreateProfileInputRequest
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,13 +19,24 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/profiles")
 class CreateProfile(private val profileService: ProfileService) {
     @PostMapping
-    suspend fun createProfile(@RequestBody input: CreateProfileInput): CreateProfileOutput {
-        val createdProfile = profileService.createProfile(input)
+    suspend fun createProfile(
+            @RequestBody request: CreateProfileInputRequest,
+            authentication: JwtAuthenticationToken,
+        ): CreateProfileOutput {
+        val userId = authentication.token.subject
+
+        val input = CreateProfileInput.builder()
+            .username(request.username)
+            .firstName(request.firstName)
+            .lastName(request.lastName)
+            .email(request.email)
+            .phoneNumber(request.phoneNumber)
+            .build()
+
+        val createdProfile = profileService.createProfile(input, userId)
 
         return CreateProfileOutput.builder()
             .profile(createdProfile)
             .build()
     }
-
-    // TODO: Add input validation for [CreateProfileInput]
 }

--- a/src/main/kotlin/com/quri/management/handlers/profiles/DeleteProfile.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/DeleteProfile.kt
@@ -18,16 +18,14 @@ import org.springframework.web.bind.annotation.RestController
 class DeleteProfile(private val profileService: ProfileService) {
     @DeleteMapping
     suspend fun deleteProfile(@PathVariable profileId: String): DeleteProfileOutput {
-        val input = deleteProfileInput(profileId)
+        val input = DeleteProfileInput.builder()
+            .profileId(profileId)
+            .build()
+
         val deletedProfileId = profileService.deleteProfile(input)
 
         return DeleteProfileOutput.builder()
             .profileId(deletedProfileId)
             .build()
     }
-
-    private fun deleteProfileInput(profileId: String): DeleteProfileInput =
-        DeleteProfileInput.builder()
-            .profileId(profileId)
-            .build()
 }

--- a/src/main/kotlin/com/quri/management/handlers/profiles/GetProfile.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/GetProfile.kt
@@ -18,16 +18,14 @@ import org.springframework.web.bind.annotation.RestController
 class GetProfile(private val profileService: ProfileService) {
     @GetMapping
     suspend fun getProfile(@PathVariable profileId: String): GetProfileOutput {
-        val input = getProfileInput(profileId)
+        val input = GetProfileInput.builder()
+            .profileId(profileId)
+            .build()
+
         val foundProfile = profileService.getProfileFromId(input)
 
         return GetProfileOutput.builder()
             .profile(foundProfile)
             .build()
     }
-
-    private fun getProfileInput(profileId: String): GetProfileInput =
-        GetProfileInput.builder()
-            .profileId(profileId)
-            .build()
 }

--- a/src/main/kotlin/com/quri/management/handlers/profiles/ListProfiles.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/ListProfiles.kt
@@ -21,7 +21,12 @@ class ListProfiles(private val profileService: ProfileService) {
         @RequestParam maxResults: Int?,
         @RequestParam nextToken: String?,
     ): ListProfilesOutput {
-        val input = listProfilesInput(maxResults, nextToken)
+        val pageSize = (maxResults ?: DEFAULT_PROFILE_PAGE_SIZE).coerceIn(1, MAX_PROFILE_PAGE_SIZE)
+        val input = ListProfilesInput.builder()
+            .maxResults(pageSize)
+            .nextToken(nextToken)
+            .build()
+
         val (profiles, newToken) = profileService.listProfiles(
             pageSize = input.maxResults,
             nextToken = input.nextToken,
@@ -30,17 +35,6 @@ class ListProfiles(private val profileService: ProfileService) {
         return ListProfilesOutput.builder()
             .profiles(profiles)
             .nextToken(newToken)
-            .build()
-    }
-
-    private fun listProfilesInput(
-        maxResults: Int?,
-        nextToken: String?,
-    ): ListProfilesInput {
-        val pageSize = (maxResults ?: DEFAULT_PROFILE_PAGE_SIZE).coerceIn(1, MAX_PROFILE_PAGE_SIZE)
-        return ListProfilesInput.builder()
-            .maxResults(pageSize)
-            .nextToken(nextToken)
             .build()
     }
 

--- a/src/main/kotlin/com/quri/management/services/BillService.kt
+++ b/src/main/kotlin/com/quri/management/services/BillService.kt
@@ -32,11 +32,12 @@ class BillService(private val billCollection: BillCollection) {
      * Creates a new bill.
      *
      * @param input contains the total and balance for the new bill
+     * @param ownerId the owning entity
      * @return the persisted [Bill] with its generated ID
      * @throws InternalFailureException if the insert did not return a generated ID
      */
-    suspend fun createBill(input: CreateBillInput): Bill =
-        billCollection.create(input)
+    suspend fun createBill(input: CreateBillInput, ownerId: String): Bill =
+        billCollection.create(input, ownerId)
             ?: throw InternalFailureException.builder()
                 .message("Failed to create bill")
                 .build()

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -33,11 +33,12 @@ class ProfileService(private val profileCollection: ProfileCollection) {
      * Creates a new profile.
      *
      * @param input contains the user's personal info
+     * @param ownerId the owning entity
      * @return the persisted [Profile] with its generated ID
      * @throws InternalFailureException if the insert did not return a generated ID
      */
-    suspend fun createProfile(input: CreateProfileInput): Profile =
-        profileCollection.create(input)
+    suspend fun createProfile(input: CreateProfileInput, ownerId: String): Profile =
+        profileCollection.create(input, ownerId)
             ?: throw InternalFailureException.builder()
                 .message("Failed to create profile")
                 .build()

--- a/src/main/kotlin/com/quri/management/validators/inputs/bills/CreateBillInputRequest.kt
+++ b/src/main/kotlin/com/quri/management/validators/inputs/bills/CreateBillInputRequest.kt
@@ -1,0 +1,19 @@
+package com.quri.management.validators.inputs.bills
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.CreateBillInput
+import com.quri.management.validators.models.MonetaryAmountRequest
+
+/**
+ * Maps this request to a Smithy [CreateBillInput].
+ */
+data class CreateBillInputRequest(
+    @JsonProperty("total") val total: MonetaryAmountRequest? = null,
+    @JsonProperty("balance") val balance: MonetaryAmountRequest? = null,
+) {
+    fun toSmithyModel(): CreateBillInput =
+        CreateBillInput.builder()
+            .total(total?.toSmithyModel())
+            .balance(balance?.toSmithyModel())
+            .build()
+}

--- a/src/main/kotlin/com/quri/management/validators/inputs/profiles/CreateProfileInputRequest.kt
+++ b/src/main/kotlin/com/quri/management/validators/inputs/profiles/CreateProfileInputRequest.kt
@@ -1,0 +1,24 @@
+package com.quri.management.validators.inputs.profiles
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.CreateProfileInput
+
+/**
+ * Maps this request to a Smithy [CreateProfileInput].
+ */
+data class CreateProfileInputRequest(
+    @JsonProperty("username") val username: String? = null,
+    @JsonProperty("firstName") val firstName: String ?= null,
+    @JsonProperty("lastName") val lastName: String ?= null,
+    @JsonProperty("email") val email: String ?= null,
+    @JsonProperty("phoneNumber") val phoneNumber: String? = null,
+) {
+    fun toSmithyModel(): CreateProfileInput =
+        CreateProfileInput.builder()
+            .username(username)
+            .firstName(firstName)
+            .lastName(lastName)
+            .email(email)
+            .phoneNumber(phoneNumber)
+            .build()
+}

--- a/src/main/kotlin/com/quri/management/validators/models/MonetaryAmountRequest.kt
+++ b/src/main/kotlin/com/quri/management/validators/models/MonetaryAmountRequest.kt
@@ -1,0 +1,19 @@
+package com.quri.management.validators.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.MonetaryAmount
+import java.math.BigDecimal
+
+/**
+ * Maps this request to a Smithy [MonetaryAmount].
+ */
+data class MonetaryAmountRequest(
+    @JsonProperty("amount") val amount: BigDecimal? = null,
+    @JsonProperty("currency") val currency: String? = null,
+) {
+    fun toSmithyModel(): MonetaryAmount =
+        MonetaryAmount.builder()
+            .amount(amount)
+            .currency(currency)
+            .build()
+}


### PR DESCRIPTION
## What

Fixed request body deserialization errors occurring after migrating from Smithy server code generation to Spring WebFlux. Added proper ownership tracking for all created domain objects (Profiles and Bills) which associates created resources with the authenticated user who created them.

## Why

During the migration to WebFlux:

1. Request bodies were not being correctly serialized/deserialized causing unhandled runtime exceptions on all write operations
2. No ownership context was being set when creating new objects which meant created resources had no association with the user account that created them, breaking security boundaries and data isolation
3. This resulted in 500 internal server errors for all creation endpoints and lack of proper access control

## How

- Fixed Jackson object mapper configuration for WebFlux request body handling
- Added correct deserialization support for request DTOs
- Added createdBy user identifier field to both Bill and Profile database documents
- Updated service layer methods to extract authenticated user context from SecurityContext
- Populated ownership metadata automatically on all object creation operations
- Adjusted handler methods to properly pass through authentication context to service layer
- Updated input validation to work correctly with WebFlux reactive pipeline

## Next Steps

Now that we can serialize incoming requests, we are ready to expand towards validation of inputs and error handling on outputs. The final arc is locking down objects to respective owners via `role` and `ownerId` which are both found in the Clerk-issued JWT.