### PR TITLE
[REFACTOR]: add UserIdentity interface to read from context

### DIFF
--- a/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
@@ -47,7 +47,10 @@ class BillCollection(dataStoreDatabase: MongoDatabase) {
      * @return the persisted [Bill] with [Bill.id] populated, or `null` if
      * the insert did not return a generated ID
      */
-    suspend fun create(input: CreateBillInput, ownerId: String): Bill? {
+    suspend fun create(
+        input: CreateBillInput,
+        ownerId: String,
+    ): Bill? {
         val doc = BillDocument(
             total = MonetaryAmountDocument(input.total.amount, input.total.currency),
             balance = MonetaryAmountDocument(input.balance.amount, input.balance.currency),

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -47,7 +47,10 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
      * @return the persisted [Profile] with [Profile.id] populated, or `null` if
      * the insert did not return a generated ID
      */
-    suspend fun create(input: CreateProfileInput, ownerId: String): Profile? {
+    suspend fun create(
+        input: CreateProfileInput,
+        ownerId: String,
+    ): Profile? {
         val doc = ProfileDocument(
             username = input.username,
             firstName = input.firstName,

--- a/src/main/kotlin/com/quri/management/handlers/bills/CreateBill.kt
+++ b/src/main/kotlin/com/quri/management/handlers/bills/CreateBill.kt
@@ -2,9 +2,9 @@ package com.quri.management.handlers.bills
 
 import com.quri.client.model.CreateBillInput
 import com.quri.client.model.CreateBillOutput
+import com.quri.management.security.identity.UserIdentity
 import com.quri.management.services.BillService
 import com.quri.management.validators.inputs.bills.CreateBillInputRequest
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,22 +17,15 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/bills")
-class CreateBill(
-    private val billService: BillService,
-) {
+class CreateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
     @PostMapping
-    suspend fun createBill(
-        @RequestBody request: CreateBillInputRequest,
-        authentication: JwtAuthenticationToken,
-    ): CreateBillOutput {
-        val userId = authentication.token.subject
-
+    suspend fun createBill(@RequestBody request: CreateBillInputRequest): CreateBillOutput {
         val input = CreateBillInput.builder()
             .total(request.total?.toSmithyModel())
             .balance(request.balance?.toSmithyModel())
             .build()
 
-        val created = billService.createBill(input, userId)
+        val created = billService.createBill(input, userIdentity.userId())
 
         return CreateBillOutput.builder()
             .bill(created)

--- a/src/main/kotlin/com/quri/management/handlers/profiles/CreateProfile.kt
+++ b/src/main/kotlin/com/quri/management/handlers/profiles/CreateProfile.kt
@@ -2,9 +2,9 @@ package com.quri.management.handlers.profiles
 
 import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.CreateProfileOutput
+import com.quri.management.security.identity.UserIdentity
 import com.quri.management.services.ProfileService
 import com.quri.management.validators.inputs.profiles.CreateProfileInputRequest
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,14 +17,13 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/profiles")
-class CreateProfile(private val profileService: ProfileService) {
+class CreateProfile(
+    private val profileService: ProfileService,
+    private val userIdentity: UserIdentity,
+    identity: UserIdentity,
+) {
     @PostMapping
-    suspend fun createProfile(
-            @RequestBody request: CreateProfileInputRequest,
-            authentication: JwtAuthenticationToken,
-        ): CreateProfileOutput {
-        val userId = authentication.token.subject
-
+    suspend fun createProfile(@RequestBody request: CreateProfileInputRequest): CreateProfileOutput {
         val input = CreateProfileInput.builder()
             .username(request.username)
             .firstName(request.firstName)
@@ -33,7 +32,7 @@ class CreateProfile(private val profileService: ProfileService) {
             .phoneNumber(request.phoneNumber)
             .build()
 
-        val createdProfile = profileService.createProfile(input, userId)
+        val createdProfile = profileService.createProfile(input, userIdentity.userId())
 
         return CreateProfileOutput.builder()
             .profile(createdProfile)

--- a/src/main/kotlin/com/quri/management/security/auth/ClerkAuthoritiesConverter.kt
+++ b/src/main/kotlin/com/quri/management/security/auth/ClerkAuthoritiesConverter.kt
@@ -36,8 +36,9 @@ class ClerkAuthoritiesConverter : Converter<Jwt, Collection<GrantedAuthority>> {
             ?.get(ROLE_CLAIM) as? String
 
     companion object {
-        private const val METADATA_CLAIM = "metadata"
-        private const val ROLE_CLAIM = "role"
-        private const val ROLE_PREFIX = "ROLE_"
+        const val METADATA_CLAIM = "metadata"
+        const val ROLE_CLAIM = "role"
+        const val ROLE_PREFIX = "ROLE_"
+        const val DEFAULT_ROLE = "guest"
     }
 }

--- a/src/main/kotlin/com/quri/management/security/identity/ClerkUserIdentity.kt
+++ b/src/main/kotlin/com/quri/management/security/identity/ClerkUserIdentity.kt
@@ -1,0 +1,39 @@
+package com.quri.management.security.identity
+
+import com.quri.management.security.auth.ClerkAuthoritiesConverter
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.security.core.context.ReactiveSecurityContextHolder
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.stereotype.Component
+
+/**
+ * Reads the current user's identity from the reactive security context.
+ */
+@Component
+class ClerkUserIdentity : UserIdentity {
+
+    override suspend fun userId(): String =
+        authentication().token.subject
+            ?: error("Could not resolve userId")
+
+    override suspend fun role(): String =
+        authentication().authorities
+            .firstOrNull { it.authority?.startsWith(ClerkAuthoritiesConverter.ROLE_PREFIX) == true }
+            ?.authority
+            ?.removePrefix(ClerkAuthoritiesConverter.ROLE_PREFIX)
+            ?.lowercase()
+            ?: ClerkAuthoritiesConverter.DEFAULT_ROLE
+
+    /**
+     * Retrieves JWT authentication token from the reactive security context.
+     * Populated after verifying the JWT signature, it throws if called outside
+     * an authenticated request.
+     */
+    private suspend fun authentication(): JwtAuthenticationToken =
+        ReactiveSecurityContextHolder.getContext()
+            .map {
+                it.authentication as? JwtAuthenticationToken
+                    ?: error("No authenticated JWT in SecurityContext")
+            }
+            .awaitSingle()
+}

--- a/src/main/kotlin/com/quri/management/security/identity/UserIdentity.kt
+++ b/src/main/kotlin/com/quri/management/security/identity/UserIdentity.kt
@@ -1,0 +1,22 @@
+package com.quri.management.security.identity
+
+/**
+ * Abstracts the current authenticated user from underlying auth provider.
+ *
+ * All methods are suspended because reading from reactive security context
+ * is an async operation in WebFlux.
+ *
+ * Controllers and services depend on this interface rather than Spring Security
+ * directly, meaning the auth provider can be swapped without affecting downstream logic.
+ */
+interface UserIdentity {
+    /**
+     * A user identifier from the JWT `sub` claim used as foreign key to created objects.
+     */
+    suspend fun userId(): String
+
+    /**
+     * Raw role string stored in auth provider's metadata.
+     */
+    suspend fun role(): String
+}

--- a/src/main/kotlin/com/quri/management/services/BillService.kt
+++ b/src/main/kotlin/com/quri/management/services/BillService.kt
@@ -36,7 +36,10 @@ class BillService(private val billCollection: BillCollection) {
      * @return the persisted [Bill] with its generated ID
      * @throws InternalFailureException if the insert did not return a generated ID
      */
-    suspend fun createBill(input: CreateBillInput, ownerId: String): Bill =
+    suspend fun createBill(
+        input: CreateBillInput,
+        ownerId: String,
+    ): Bill =
         billCollection.create(input, ownerId)
             ?: throw InternalFailureException.builder()
                 .message("Failed to create bill")

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -37,7 +37,10 @@ class ProfileService(private val profileCollection: ProfileCollection) {
      * @return the persisted [Profile] with its generated ID
      * @throws InternalFailureException if the insert did not return a generated ID
      */
-    suspend fun createProfile(input: CreateProfileInput, ownerId: String): Profile =
+    suspend fun createProfile(
+        input: CreateProfileInput,
+        ownerId: String,
+    ): Profile =
         profileCollection.create(input, ownerId)
             ?: throw InternalFailureException.builder()
                 .message("Failed to create profile")

--- a/src/main/kotlin/com/quri/management/validators/inputs/profiles/CreateProfileInputRequest.kt
+++ b/src/main/kotlin/com/quri/management/validators/inputs/profiles/CreateProfileInputRequest.kt
@@ -8,9 +8,9 @@ import com.quri.client.model.CreateProfileInput
  */
 data class CreateProfileInputRequest(
     @JsonProperty("username") val username: String? = null,
-    @JsonProperty("firstName") val firstName: String ?= null,
-    @JsonProperty("lastName") val lastName: String ?= null,
-    @JsonProperty("email") val email: String ?= null,
+    @JsonProperty("firstName") val firstName: String? = null,
+    @JsonProperty("lastName") val lastName: String? = null,
+    @JsonProperty("email") val email: String? = null,
     @JsonProperty("phoneNumber") val phoneNumber: String? = null,
 ) {
     fun toSmithyModel(): CreateProfileInput =


### PR DESCRIPTION
Features an abstraction layer to be able to swap between authenticator providers when looking for userId and roles in the security context.

Also includes detekt formatting changes.