### PR TITLE
[FEAT]: add serialization and loose validation on Profile DTO layer

### DIFF
--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/CreateProfile.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/CreateProfile.kt
@@ -1,8 +1,8 @@
 package com.quri.management.api.handlers.profiles
 
-import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.CreateProfileOutput
 import com.quri.management.api.inputs.profiles.CreateProfileInputRequest
+import com.quri.management.api.outputs.profiles.ProfileResponse
 import com.quri.management.api.security.identity.UserIdentity
 import com.quri.management.services.ProfileService
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,25 +17,17 @@ import org.springframework.web.bind.annotation.RestController
  */
 @RestController
 @RequestMapping("/profiles")
-class CreateProfile(
-    private val profileService: ProfileService,
-    private val userIdentity: UserIdentity,
-    identity: UserIdentity,
-) {
+class CreateProfile(private val profileService: ProfileService, private val userIdentity: UserIdentity) {
     @PostMapping
-    suspend fun createProfile(@RequestBody request: CreateProfileInputRequest): CreateProfileOutput {
-        val input = CreateProfileInput.builder()
-            .username(request.username)
-            .firstName(request.firstName)
-            .lastName(request.lastName)
-            .email(request.email)
-            .phoneNumber(request.phoneNumber)
-            .build()
+    suspend fun createProfile(@RequestBody request: CreateProfileInputRequest): ProfileResponse {
+        val input = request.toSmithyInput()
 
         val createdProfile = profileService.createProfile(input, userIdentity.userId())
 
-        return CreateProfileOutput.builder()
+        val output = CreateProfileOutput.builder()
             .profile(createdProfile)
             .build()
+
+        return ProfileResponse.from(output)
     }
 }

--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/DeleteProfile.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/DeleteProfile.kt
@@ -2,6 +2,7 @@ package com.quri.management.api.handlers.profiles
 
 import com.quri.client.model.DeleteProfileInput
 import com.quri.client.model.DeleteProfileOutput
+import com.quri.management.api.outputs.profiles.DeleteProfileResponse
 import com.quri.management.services.ProfileService
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -9,23 +10,23 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Handles the [DeleteProfile] operation.
- *
- * @see ProfileService.deleteProfile
+ * Handles the profile deletion operation.
  */
 @RestController
 @RequestMapping("/profiles/{profileId}")
 class DeleteProfile(private val profileService: ProfileService) {
     @DeleteMapping
-    suspend fun deleteProfile(@PathVariable profileId: String): DeleteProfileOutput {
+    suspend fun deleteProfile(@PathVariable profileId: String): DeleteProfileResponse {
         val input = DeleteProfileInput.builder()
             .profileId(profileId)
             .build()
 
         val deletedProfileId = profileService.deleteProfile(input)
 
-        return DeleteProfileOutput.builder()
+        val output = DeleteProfileOutput.builder()
             .profileId(deletedProfileId)
             .build()
+
+        return DeleteProfileResponse.from(output)
     }
 }

--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/GetProfile.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/GetProfile.kt
@@ -2,6 +2,7 @@ package com.quri.management.api.handlers.profiles
 
 import com.quri.client.model.GetProfileInput
 import com.quri.client.model.GetProfileOutput
+import com.quri.management.api.outputs.profiles.ProfileResponse
 import com.quri.management.services.ProfileService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -9,23 +10,23 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Handles the [GetProfile] operation.
- *
- * @see ProfileService.getProfileFromId
+ * Handles the profile retrieval operation.
  */
 @RestController
 @RequestMapping("/profiles/{profileId}")
 class GetProfile(private val profileService: ProfileService) {
     @GetMapping
-    suspend fun getProfile(@PathVariable profileId: String): GetProfileOutput {
+    suspend fun getProfile(@PathVariable profileId: String): ProfileResponse {
         val input = GetProfileInput.builder()
             .profileId(profileId)
             .build()
 
         val found = profileService.getProfileFromId(input)
 
-        return GetProfileOutput.builder()
+        val output = GetProfileOutput.builder()
             .profile(found)
             .build()
+
+        return ProfileResponse.from(output)
     }
 }

--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/ListProfiles.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/ListProfiles.kt
@@ -2,6 +2,7 @@ package com.quri.management.api.handlers.profiles
 
 import com.quri.client.model.ListProfilesInput
 import com.quri.client.model.ListProfilesOutput
+import com.quri.management.api.outputs.profiles.ListProfilesResponse
 import com.quri.management.services.ProfileService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -9,9 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Handles the [ListProfiles] operation.
- *
- * @see ProfileService.listProfiles
+ * Handles the list profiles operation.
  */
 @RestController
 @RequestMapping("/profiles")
@@ -20,7 +19,7 @@ class ListProfiles(private val profileService: ProfileService) {
     suspend fun listProfiles(
         @RequestParam maxResults: Int?,
         @RequestParam nextToken: String?,
-    ): ListProfilesOutput {
+    ): ListProfilesResponse {
         val pageSize = (maxResults ?: DEFAULT_PROFILE_PAGE_SIZE).coerceIn(1, MAX_PROFILE_PAGE_SIZE)
         val input = ListProfilesInput.builder()
             .maxResults(pageSize)
@@ -32,10 +31,12 @@ class ListProfiles(private val profileService: ProfileService) {
             nextToken = input.nextToken,
         )
 
-        return ListProfilesOutput.builder()
+        val output = ListProfilesOutput.builder()
             .profiles(profiles)
             .nextToken(newToken)
             .build()
+
+        return ListProfilesResponse.from(output)
     }
 
     companion object {

--- a/src/main/kotlin/com/quri/management/api/handlers/receipts/ListReceipts.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/receipts/ListReceipts.kt
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+/**
+ * Handles the list receipts operation.
+ */
 @RestController
 @RequestMapping("/receipts")
 class ListReceipts(private val receiptService: ReceiptService) {

--- a/src/main/kotlin/com/quri/management/api/inputs/profiles/CreateProfileInputRequest.kt
+++ b/src/main/kotlin/com/quri/management/api/inputs/profiles/CreateProfileInputRequest.kt
@@ -12,14 +12,53 @@ data class CreateProfileInputRequest(
     @JsonProperty("lastName") val lastName: String,
     @JsonProperty("email") val email: String,
 
+    @JsonProperty("middleName") val middleName: String? = null,
     @JsonProperty("phoneNumber") val phoneNumber: String? = null,
 ) {
+    init {
+        require(
+            username.isNotBlank() &&
+                username.length in MIN_USERNAME_LENGTH..MAX_USERNAME_LENGTH,
+        ) { "username is invalid" }
+        require(
+            firstName.isNotBlank() &&
+                firstName.length <= MAX_NAME_LENGTH,
+        ) { "firstName is invalid" }
+        require(
+            lastName.isNotBlank() &&
+                lastName.length <= MAX_NAME_LENGTH,
+        ) { "lastName is invalid" }
+        require(
+            email.isNotBlank() &&
+                email.matches(Regex("""^[^@\s]+@[^@\s]+\.[^@\s]+$""")),
+        ) { "email is invalid" }
+
+        middleName?.let {
+            require(
+                it.isNotBlank() &&
+                        middleName.length <= MAX_NAME_LENGTH
+            ) { "middleName is invalid" }
+        }
+        phoneNumber?.let {
+            require(it.matches(Regex("""^[+0-9()\-\s]{10,20}$"""))) {
+                "phoneNumber is invalid"
+            }
+        }
+    }
+
     fun toSmithyInput(): CreateProfileInput =
         CreateProfileInput.builder()
             .username(username)
             .firstName(firstName)
             .lastName(lastName)
             .email(email)
+            .middleName(middleName)
             .phoneNumber(phoneNumber)
             .build()
+
+    companion object {
+        private const val MIN_USERNAME_LENGTH = 3
+        private const val MAX_USERNAME_LENGTH = 30
+        private const val MAX_NAME_LENGTH = 50
+    }
 }

--- a/src/main/kotlin/com/quri/management/api/outputs/profiles/DeleteProfileResponse.kt
+++ b/src/main/kotlin/com/quri/management/api/outputs/profiles/DeleteProfileResponse.kt
@@ -1,0 +1,17 @@
+package com.quri.management.api.outputs.profiles
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.DeleteProfileOutput
+import com.quri.client.model.Profile
+
+/**
+ * Maps the [Profile] delete result to a client-facing response.
+ */
+data class DeleteProfileResponse(@JsonProperty("profileId") val profileId: String?) {
+    companion object {
+        fun from(model: DeleteProfileOutput) =
+            DeleteProfileResponse(
+                profileId = model.profileId,
+            )
+    }
+}

--- a/src/main/kotlin/com/quri/management/api/outputs/profiles/ListProfilesResponse.kt
+++ b/src/main/kotlin/com/quri/management/api/outputs/profiles/ListProfilesResponse.kt
@@ -1,0 +1,21 @@
+package com.quri.management.api.outputs.profiles
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.ListProfilesOutput
+import com.quri.client.model.Profile
+
+/**
+ * Maps a paginated list of Smithy [Profile] models to a client-facing response.
+ */
+data class ListProfilesResponse(
+    @JsonProperty("profiles") val profiles: List<ProfileResponse>,
+    @JsonProperty("nextToken") val nextToken: String? = null,
+) {
+    companion object {
+        fun from(model: ListProfilesOutput) =
+            ListProfilesResponse(
+                profiles = model.profiles.map { ProfileResponse.from(it) },
+                nextToken = model.nextToken,
+            )
+    }
+}

--- a/src/main/kotlin/com/quri/management/api/outputs/profiles/ProfileResponse.kt
+++ b/src/main/kotlin/com/quri/management/api/outputs/profiles/ProfileResponse.kt
@@ -1,0 +1,62 @@
+package com.quri.management.api.outputs.profiles
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.CreateProfileOutput
+import com.quri.client.model.GetProfileOutput
+import com.quri.client.model.Profile
+import com.quri.management.shared.models.ProfileLocation
+import java.time.Instant
+
+/**
+ * Maps a Smithy [Profile] to a client-facing response.
+ *
+ */
+data class ProfileResponse(
+    @JsonProperty("id") val id: String,
+    @JsonProperty("username") val username: String,
+    @JsonProperty("firstName") val firstName: String,
+    @JsonProperty("lastName") val lastName: String,
+    @JsonProperty("email") val email: String,
+
+    @JsonProperty("following") val following: List<String>? = emptyList(),
+    @JsonProperty("followers") val followers: List<String>? = emptyList(),
+    @JsonProperty("middleName") val middleName: String? = null,
+    @JsonProperty("phoneNumber") val phoneNumber: String? = null,
+    @JsonProperty("bio") val bio: String? = null,
+
+    @JsonProperty("gender") val gender: String? = null,
+    @JsonProperty("dateOfBirth") val dateOfBirth: Instant? = null,
+    @JsonProperty("location") val location: ProfileLocation? = null,
+
+    @JsonProperty("createdAt") val createdAt: Instant,
+    @JsonProperty("createdBy") val createdBy: String,
+    @JsonProperty("updatedAt") val updatedAt: Instant,
+    @JsonProperty("updatedBy") val updatedBy: String,
+) {
+    companion object {
+        fun from(model: CreateProfileOutput) = fromProfile(model.profile)
+        fun from(model: GetProfileOutput) = fromProfile(model.profile)
+        fun from(model: Profile) = fromProfile(model)
+
+        private fun fromProfile(model: Profile) =
+            ProfileResponse(
+                id = model.id,
+                username = model.username,
+                firstName = model.firstName,
+                lastName = model.lastName,
+                email = model.email,
+                following = model.following,
+                followers = model.followers,
+                middleName = model.middleName,
+                phoneNumber = model.phoneNumber,
+                bio = model.bio,
+                gender = model.gender?.value,
+                dateOfBirth = model.dateOfBirth,
+                location = model.location?.let { ProfileLocation.from(it) },
+                createdAt = model.createdAt,
+                createdBy = model.createdBy,
+                updatedAt = model.updatedAt,
+                updatedBy = model.updatedBy,
+            )
+    }
+}

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -58,6 +58,7 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
             firstName = input.firstName,
             lastName = input.lastName,
             email = input.email,
+            middleName = input.middleName,
             phoneNumber = input.phoneNumber,
             createdBy = ownerId,
             createdAt = currTime,

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
@@ -1,6 +1,8 @@
 package com.quri.management.db.mongo.documents
 
+import com.quri.client.model.Gender
 import com.quri.client.model.Profile
+import com.quri.management.shared.models.ProfileLocation
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 import java.time.Instant
@@ -17,7 +19,14 @@ data class ProfileDocument(
     val lastName: String,
     val email: String,
 
+    val following: List<String>? = emptyList(),
+    val followers: List<String>? = emptyList(),
+    val middleName: String? = null,
     val phoneNumber: String? = null,
+    val bio: String? = null,
+    val gender: String? = null,
+    val dateOfBirth: Instant? = null,
+    val location: ProfileLocation? = null,
 
     val createdBy: String,
     val createdAt: Instant,
@@ -31,7 +40,14 @@ data class ProfileDocument(
             .firstName(firstName)
             .lastName(lastName)
             .email(email)
+            .following(following)
+            .followers(followers)
+            .middleName(middleName)
             .phoneNumber(phoneNumber)
+            .bio(bio)
+            .gender(gender?.let { Gender.from(it) })
+            .dateOfBirth(dateOfBirth)
+            .location(location?.toSmithyModel())
             .createdBy(createdBy)
             .createdAt(createdAt)
             .updatedBy(updatedBy)

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -26,7 +26,7 @@ class ProfileService(private val profileCollection: ProfileCollection) {
     suspend fun getProfileFromId(input: GetProfileInput): Profile =
         profileCollection.findById(ObjectId(input.profileId))
             ?: throw ResourceNotFoundException.builder()
-                .message("Profile with id ${input.profileId} not found")
+                .message("Profile with ID `${input.profileId}` not found")
                 .build()
 
     /**
@@ -68,6 +68,6 @@ class ProfileService(private val profileCollection: ProfileCollection) {
     suspend fun deleteProfile(input: DeleteProfileInput): String =
         profileCollection.deleteById(ObjectId(input.profileId))?.toString()
             ?: throw ResourceNotFoundException.builder()
-                .message("Profile with id ${input.profileId} not found")
+                .message("Profile with ID `${input.profileId}` not found")
                 .build()
 }

--- a/src/main/kotlin/com/quri/management/shared/models/ProfileLocation.kt
+++ b/src/main/kotlin/com/quri/management/shared/models/ProfileLocation.kt
@@ -1,0 +1,31 @@
+package com.quri.management.shared.models
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.quri.client.model.ProfileLocation as SmithyProfileLocation
+
+/**
+ * Maps to a user's general location for demographic data.
+ *
+ * @see SmithyProfileLocation
+ */
+data class ProfileLocation(
+    @JsonProperty("city") val city: String,
+    @JsonProperty("state") val state: String,
+    @JsonProperty("country") val country: String,
+) {
+    fun toSmithyModel(): SmithyProfileLocation =
+        SmithyProfileLocation.builder()
+            .city(city)
+            .state(state)
+            .country(country)
+            .build()
+
+    companion object {
+        fun from(model: SmithyProfileLocation) =
+            ProfileLocation(
+                city = model.city,
+                state = model.state,
+                country = model.country,
+            )
+    }
+}


### PR DESCRIPTION
## What

Added serialization and response handling for `Profile` operations which would occasionally break or expose too much of our Smithy types if not handled correctly. Additionally, more fields added to `Profile` entity with loose validation to save us from having to recheck at the service layer.

## How

Keep Smithy Input/Output in the loop even though we are handling our input and outputs ourselves.

## Test

Positive:
```
{
  "username": "jane_smith",
  "firstName": "Jane",
  "middleName": "Marie",
  "lastName": "Smith",
  "email": "jane.smith@outlook.com",
  "phoneNumber": "+12025551234"
}
```

Negative:
```
{
  "username": "jd",
  "firstName": "John",
  "middleName": "",
  "lastName": "Doe",
  "email": "notanemail",
  "phoneNumber": "123"
}
```