### PR TITLE
[FEAT](validation): add one email per profile validation

### DIFF
--- a/src/main/kotlin/com/quri/management/api/validation/Validator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/Validator.kt
@@ -10,7 +10,7 @@ import com.quri.client.model.ValidationException
  * for use in error messages.
  */
 fun interface Validator<T> {
-    fun validate(
+    suspend fun validate(
         field: String,
         input: T,
     )

--- a/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class CreateBillValidator : Validator<CreateBillInput> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: CreateBillInput,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/AddressValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/AddressValidator.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class AddressValidator : Validator<Address> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: Address,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/DiscountValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/DiscountValidator.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class DiscountValidator(private val monetaryAmountValidator: MonetaryAmountValidator) : Validator<Discount> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: Discount,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/FeeValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/FeeValidator.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class FeeValidator(private val monetaryAmountValidator: MonetaryAmountValidator) : Validator<Fee> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: Fee,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/ItemValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/ItemValidator.kt
@@ -12,7 +12,7 @@ class ItemValidator(
     private val liableValidator: LiableValidator,
     private val discountValidator: DiscountValidator,
 ) : Validator<Item> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: Item,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/LiableValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/LiableValidator.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class LiableValidator : Validator<Liable> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: Liable,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/model/MonetaryAmountValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/MonetaryAmountValidator.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class MonetaryAmountValidator : Validator<MonetaryAmount> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: MonetaryAmount,
     ) {

--- a/src/main/kotlin/com/quri/management/api/validation/profile/CreateProfileValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/profile/CreateProfileValidator.kt
@@ -1,17 +1,22 @@
 package com.quri.management.api.validation.profile
 
+import com.mongodb.client.model.Filters.eq
 import com.quri.client.model.CreateProfileInput
+import com.quri.client.model.ValidationException
 import com.quri.management.api.validation.Validator
 import com.quri.management.api.validation.validateLength
 import com.quri.management.api.validation.validatePattern
+import com.quri.management.db.mongo.collections.ProfileCollection
+import com.quri.management.db.mongo.documents.ProfileDocument
 import org.springframework.stereotype.Component
 
 @Component
-class CreateProfileValidator : Validator<CreateProfileInput> {
-    override fun validate(
+class CreateProfileValidator(private val profileCollection: ProfileCollection) : Validator<CreateProfileInput> {
+    override suspend fun validate(
         field: String,
         input: CreateProfileInput,
     ) {
+        // Inputs
         input.username?.validateLength("$field.username", MIN_USERNAME_LENGTH, MAX_USERNAME_LENGTH)
         input.firstName?.validateLength("$field.firstName", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
         input.lastName?.validateLength("$field.lastName", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
@@ -22,6 +27,13 @@ class CreateProfileValidator : Validator<CreateProfileInput> {
             Regex("^[+0-9()\\-\\s]{10,20}$"),
             "phone number is invalid",
         )
+
+        // Logic
+        require(!profileCollection.exists(eq(ProfileDocument::email.name, input.email))) {
+            throw ValidationException.builder()
+                .message("A profile with email '${input.email}' already exists")
+                .build()
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/quri/management/api/validation/receipt/CreateReceiptValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/receipt/CreateReceiptValidator.kt
@@ -18,7 +18,7 @@ class CreateReceiptValidator(
     private val addressValidator: AddressValidator,
     private val itemValidator: ItemValidator,
 ) : Validator<CreateReceiptInput> {
-    override fun validate(
+    override suspend fun validate(
         field: String,
         input: CreateReceiptInput,
     ) {

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -9,6 +9,7 @@ import com.quri.management.db.mongo.MongoSchema.Collections.PROFILES
 import com.quri.management.db.mongo.documents.ProfileDocument
 import com.quri.management.db.mongo.paginate
 import kotlinx.coroutines.flow.firstOrNull
+import org.bson.conversions.Bson
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
 
@@ -78,4 +79,12 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
         val result = collection.deleteOne(eq("_id", id))
         return id.takeIf { result.deletedCount == 1L }
     }
+
+    /**
+     * Determines if an entry in the collection exists with the given criteria.
+     *
+     * @param filter the query filter to match against (e.g., `eq("email", value)`)
+     * @return true if at least one document matches the filter, false otherwise
+     */
+    suspend fun exists(filter: Bson): Boolean = collection.find(filter).limit(1).firstOrNull() != null
 }


### PR DESCRIPTION
### What

Implemented unique email validation on profile creation. Updated entire validation system to support suspend functions enabling database queries during validation. Affects Validator interface, all validator implementations, ProfileCollection, and CreateProfile operation.

### Why

Previously the system allowed duplicate email addresses across multiple user profiles which created inconsistent user identity state. This guarantees data integrity at the API boundary before database insertion, returns clear user-facing error messages, and enables future stateful validation patterns across all resources.

- Eliminates duplicate profile records for the same email address
- Validation now supports database lookups and async operations
- Proper error context is preserved and returned to API consumers

### How

- Converted `Validator` interface method from blocking to suspend function
- Updated __all 9 validator implementations__ with suspend modifier to maintain interface contract
- Added generic `exists()` method to ProfileCollection for efficient existence checks
- Injected ProfileCollection into CreateProfileValidator
- Added unique email check with proper ValidationException wrapping

---

## Next

1. Add database unique index on profile email field (required for true atomic guarantee)
2. Extend unique validation to username field
3. Implement same pattern for Bill/Receipt business constraint validations
