### PR TITLE
[FEAT](bills): add PUT endpoint for bills with service layer validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ All endpoints require authentication via a Clerk JWT (`Authorization: Bearer <to
 
 ### Bills
 
-| Method | Path | Description |
-|---|---|---|
-| `POST` | `/bills` | Create a bill |
-| `PUT` | `/bills` | Update a bill |
-| `GET` | `/bills/{id}` | Get a bill |
-| `GET` | `/bills` | List all bills |
-| `DELETE` | `/bills/{id}` | Delete a bill |
+| Method   | Path | Description             |
+|----------|---|-------------------------|
+| `POST`   | `/bills` | Create a bill           |
+| `PATCH`  | `/bills` | Partially update a bill |
+| `GET`    | `/bills/{id}` | Get a bill              |
+| `GET`    | `/bills` | List all bills          |
+| `DELETE` | `/bills/{id}` | Delete a bill           |
 
 **Create bill request body:**
 ```json

--- a/README.md
+++ b/README.md
@@ -39,16 +39,9 @@ git clone https://github.com/lizarazukevin/QuriManagementService.git
 cd QuriManagementService
 ```
 
-### 2. Configure environment variables
+### 2. Configure environment
 
-The service reads MongoDB credentials from the environment:
-
-```bash
-export MONGO_USERNAME="your_username"
-export MONGO_PASSWORD="your_password"
-export MONGO_CLUSTER="your-cluster.mongodb.net"
-export MONGO_APP_NAME="quri-management-service"
-```
+Set `MONGO_USERNAME`, `MONGO_PASSWORD`, `MONGO_CLUSTER`, and `MONGO_APP_NAME` as environment variables.
 
 ### 3. Build and run
 
@@ -82,41 +75,14 @@ This service acts as an **OAuth2 Resource Server** that validates JWTs issued by
 
 ## Code Quality
 
-This project uses static analysis tools to maintain code quality and consistency:
+[Detekt](https://detekt.dev/) and [ktlint](https://pinterest.github.io/ktlint/) enforce code style and catch potential bugs on every build.
 
-### Detekt
-[Detekt](https://detekt.dev/) is a static analysis tool for Kotlin that helps identify code smells, complexity issues, and potential bugs on every call to build. It's configured with comprehensive rules covering:
-
-- **Complexity analysis** - Detects overly complex functions and classes
-- **Naming conventions** - Enforces consistent naming patterns
-- **Performance optimizations** - Identifies potential performance issues
-- **Potential bugs** - Catches common programming mistakes
-- **Style enforcement** - Maintains consistent code formatting
-
-### ktlint
-[ktlint](https://pinterest.github.io/ktlint/) is a Kotlin code formatter that enforces the official Kotlin coding style. It automatically formats code to ensure consistency across the project.
-
-### Usage
-
-Run the linters to check code quality:
 ```bash
-./gradlew detekt
+./gradlew detekt            # check
+./gradlew detekt --auto-correct  # auto-format
 ```
 
-To quickly format your code it is recommended to enter the following:
-```shell
-./gradlew detekt --auto-correct
-```
-
-The linters are configured to:
-- Auto-correct formatting issues (ktlint)
-- Generate multiple report formats (HTML, SARIF, Markdown)
-- Integrate with your IDE for real-time feedback
-- Work with CI/CD pipelines
-
-Configuration files:
-- Main config: `config/detekt/detekt.yml`
-- Rules are based on IntelliJ IDEA style with custom project-specific settings
+Configuration: `config/detekt/detekt.yml`
 
 ---
 
@@ -149,6 +115,7 @@ All endpoints require authentication via a Clerk JWT (`Authorization: Bearer <to
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/bills` | Create a bill |
+| `PUT` | `/bills` | Update a bill |
 | `GET` | `/bills/{id}` | Get a bill |
 | `GET` | `/bills` | List all bills |
 | `DELETE` | `/bills/{id}` | Delete a bill |
@@ -175,28 +142,19 @@ This service follows a strict 3-layer boundary pattern when working with Smithy 
 | **Service Layer** | `/services` | Pure business logic that only operates on Smithy model types. No JSON, no HTTP, no framework concerns. |
 | **Database Layer** | `/db` | MongoDB persistence, directly storing and retrieving Smithy model types via custom codecs. |
 
-✅ **When you modify a Smithy file in QuriModels:**
-1. Add/update mixins in `SmithyJacksonConfig.kt` if required for API serialization
-2. Add/update Mongo codec in `/db/mongo/codecs/` if the model is stored in database
-3. Service layer will work unchanged
-
 Every request follows this exact flow:
+
 ```
 HTTP Request → Jackson (Smithy configured) → Smithy Model → Service → Smithy Model → Jackson → HTTP Response
 ```
 
+When adding a new Smithy model, wire it through serialization (`SmithyJacksonConfig.kt`), codecs (`/db/mongo/codecs/`), and the service layer as needed.
+
 ### Smithy Serialization
 
-This service uses a fully customized Jackson configuration to natively serialize and deserialize Smithy generated models without any intermediate DTO layer:
+Jackson is fully configured with custom mixins and deserializers to serialize/deserialize Smithy models directly from HTTP requests/responses — no intermediate DTO layer. See `SmithyJacksonConfig.kt`.
 
-- Custom Jackson mixins for every Smithy structure and builder class
-- Dedicated deserializers for Smithy enum types
-- Proper handling of builder patterns, nullability, and optional fields
-- Removed Kotlin Jackson module dependency as it conflicts with Smithy's immutable model design
-
-All serialization logic is contained in `SmithyJacksonConfig.kt`
-
-> SpringBoot versions 4+ ship with Jackson 3, leveraging [`JsonMapperBuilderCustomizer`](https://spring.io/blog/2025/10/07/introducing-jackson-3-support-in-spring)
+> SpringBoot 4+ ships with Jackson 3, leveraging [`JsonMapperBuilderCustomizer`](https://spring.io/blog/2025/10/07/introducing-jackson-3-support-in-spring)
 
 ---
 
@@ -204,32 +162,26 @@ All serialization logic is contained in `SmithyJacksonConfig.kt`
 
 ### Reactive stack (WebFlux)
 
-The service was migrated from Spring MVC to **Spring WebFlux** to eliminate blocking I/O on request handlers. Controllers are written as Kotlin `suspend` functions, which the framework bridges into Reactor `Mono`/`Flux` via `kotlinx-coroutines-reactor`. This keeps the runtime non-blocking end-to-end — from the Netty event loop through to the MongoDB Kotlin coroutine driver.
+The service uses Spring WebFlux with Kotlin `suspend` functions bridged into Reactor via `kotlinx-coroutines-reactor`. This keeps the runtime non-blocking end-to-end — from the Netty event loop through to the MongoDB Kotlin coroutine driver.
 
 ### Exception handling
 
-A global [`@RestControllerAdvice`](src/main/kotlin/com/quri/management/errors/GlobalExceptionHandler.kt) intercepts all exceptions before they reach the client. The policy is simple:
+A global [`@RestControllerAdvice`](src/main/kotlin/com/quri/management/errors/GlobalExceptionHandler.kt) intercepts all exceptions:
 
-- **Never expose internal details** — Clients always receive a generic message (`"An unexpected error occurred"`).
-- **Log intelligently** — 4xx errors are logged at `WARN` without a stack trace; 5xx errors are logged at `ERROR` with the full stack trace for debugging.
-- **Smithy-modeled exceptions** — `ValidationException`, `ResourceNotFoundException`, and `InternalFailureException` are mapped to `400`, `404`, and `500` respectively.
+- **4xx** errors are logged at `WARN` without a stack trace
+- **5xx** errors are logged at `ERROR` with the full stack trace
+- Clients always receive a generic error message — internal details are never exposed
+- Smithy-modeled exceptions (`ValidationException`, `ResourceNotFoundException`, `InternalFailureException`) map to `400`, `404`, and `500` respectively
 
 ### Smithy model usage
 
-Rather than using Smithy's Java server codegen (which targets blocking Netty handlers), this project consumes **Smithy client models** from [`QuriModels`](https://github.com/lizarazukevin/QuriModels) for request/response shapes, database entities, and all business logic.
+Rather than using Smithy's Java server codegen (which targets blocking Netty handlers), this project consumes **Smithy client models** from [`QuriModels`](https://github.com/lizarazukevin/QuriModels) for request/response shapes, database entities, and all business logic. The entire stack — Jackson serialization, MongoDB codecs, and the service layer — operates natively on Smithy types.
 
-The entire stack now operates natively on Smithy model types:
-✅ Jackson is fully configured to serialize/deserialize Smithy objects directly from HTTP requests/responses
-✅ MongoDB custom codecs convert Smithy models directly to/from BSON documents
-✅ Service layer works exclusively with Smithy types
-
-The controller structure (one class per operation, explicit input/output builders) is intentionally maintained so that if Smithy releases a non-blocking Kotlin server-stub codegen in the future, migration will be straightforward.
+The controller structure (one class per operation, explicit input/output builders) is maintained so that if Smithy releases a non-blocking Kotlin server-stub codegen in the future, migration will be straightforward.
 
 ### MongoDB Smithy Codecs
 
-Custom [MongoDB Codec](https://www.mongodb.com/docs/drivers/java/sync/current/data-formats/codecs/) implementations are provided for all embedded Smithy structured types (e.g.`MonetaryAmountCodec`)
-
-These codecs are registered directly in the Mongo client registry and eliminate manual mapping code between database documents and domain models. They handle proper null handling, defaults, and builder construction for Smithy immutable types.
+Custom [MongoDB Codec](https://www.mongodb.com/docs/drivers/java/sync/current/data-formats/codecs/) implementations are provided for all embedded Smithy structured types (e.g. `MonetaryAmountCodec`). These are registered directly in the Mongo client registry, eliminating manual mapping code between database documents and domain models.
 
 ---
 
@@ -262,22 +214,12 @@ This service is under active development. Known limitations:
 
 Please follow existing code style and architecture conventions. Update docs alongside code changes.
 
-> Sign your commits by creating SSH keys and adding them to your account: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
-```shell
-ssh-add ~/.ssh/id_ed25519
-git config --global gpg.format ssh
-git config --global user.signingkey ~/.ssh/id_ed25519.pub
-git config --global commit.gpgsign true
-```
-
-> When adding new ssh to github, make sure the key type is _**signing**_
-
-Add new ssh to allowlist to view signatures:
-```shell
-echo "your_email@example.com namespaces=\"git\" $(cat ~/.ssh/id_ed25519.pub)" >> ~/.ssh/allowed_signers
-git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
-```
-
+> Sign your commits via SSH. See [GitHub docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for setup, and configure signing via:
+> ```shell
+> git config --global gpg.format ssh
+> git config --global user.signingkey ~/.ssh/id_ed25519.pub
+> git config --global commit.gpgsign true
+> ```
 
 ---
 

--- a/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
@@ -1,0 +1,26 @@
+package com.quri.management.api.handlers.bills
+
+import com.quri.client.model.UpdateBillInput
+import com.quri.client.model.UpdateBillOutput
+import com.quri.management.api.security.identity.UserIdentity
+import com.quri.management.services.BillService
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Handles the bill update operation.
+ */
+@RestController
+@RequestMapping("/bills")
+class UpdateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
+    @PutMapping
+    suspend fun updateBill(@RequestBody input: UpdateBillInput): UpdateBillOutput {
+        val bill = billService.updateBill(input, userIdentity.userId())
+
+        return UpdateBillOutput.builder()
+            .bill(bill)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
@@ -4,7 +4,7 @@ import com.quri.client.model.UpdateBillInput
 import com.quri.client.model.UpdateBillOutput
 import com.quri.management.api.security.identity.UserIdentity
 import com.quri.management.services.BillService
-import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/bills")
 class UpdateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
-    @PutMapping
+    @PatchMapping
     suspend fun updateBill(@RequestBody input: UpdateBillInput): UpdateBillOutput {
         val bill = billService.updateBill(input, userIdentity.userId())
 

--- a/src/main/kotlin/com/quri/management/api/serialization/SmithyJacksonConfig.kt
+++ b/src/main/kotlin/com/quri/management/api/serialization/SmithyJacksonConfig.kt
@@ -14,6 +14,7 @@ import com.quri.client.model.Liable
 import com.quri.client.model.MonetaryAmount
 import com.quri.client.model.PaymentMethod
 import com.quri.client.model.ProfileLocation
+import com.quri.client.model.UpdateBillInput
 import com.quri.client.model.ValidationException
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
@@ -83,6 +84,9 @@ class SmithyJacksonConfig {
 
             builder.addMixIn(CreateReceiptInput::class.java, CreateReceiptInputMixin::class.java)
             builder.addMixIn(CreateReceiptInput.Builder::class.java, CreateReceiptInputBuilderMixin::class.java)
+
+            builder.addMixIn(UpdateBillInput::class.java, UpdateBillInputMixin::class.java)
+            builder.addMixIn(UpdateBillInput.Builder::class.java, UpdateBillInputBuilderMixin::class.java)
 
             builder.addMixIn(Address::class.java, AddressMixin::class.java)
             builder.addMixIn(Address.Builder::class.java, AddressBuilderMixin::class.java)
@@ -249,6 +253,9 @@ abstract class CreateProfileInputMixin
 @JsonDeserialize(builder = CreateReceiptInput.Builder::class)
 abstract class CreateReceiptInputMixin
 
+@JsonDeserialize(builder = UpdateBillInput.Builder::class)
+abstract class UpdateBillInputMixin
+
 @JsonPOJOBuilder(withPrefix = "")
 abstract class CreateProfileInputBuilderMixin
 
@@ -257,6 +264,9 @@ abstract class CreateBillInputBuilderMixin
 
 @JsonPOJOBuilder(withPrefix = "")
 abstract class CreateReceiptInputBuilderMixin
+
+@JsonPOJOBuilder(withPrefix = "")
+abstract class UpdateBillInputBuilderMixin
 
 // Nested
 @JsonDeserialize(builder = Address.Builder::class)

--- a/src/main/kotlin/com/quri/management/api/validation/bill/BillValidation.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/BillValidation.kt
@@ -1,0 +1,30 @@
+package com.quri.management.api.validation.bill
+
+import com.quri.client.model.BillStatus
+import com.quri.management.api.validation.validateLength
+
+object BillValidation {
+    const val MIN_NAME_LENGTH = 1
+    const val MAX_NAME_LENGTH = 32
+    const val MIN_DESCRIPTION_LENGTH = 1
+    const val MAX_DESCRIPTION_LENGTH = 150
+
+    fun validateName(
+        field: String,
+        name: String?,
+    ) = name?.validateLength("$field.name", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
+
+    fun validateStatusOnCreate(
+        field: String,
+        status: BillStatus?,
+    ) = status?.let {
+        require(it == BillStatus.DRAFT || it == BillStatus.PUBLISHED) {
+            "$field.status status on creation must be DRAFT or PUBLISHED"
+        }
+    }
+
+    fun validateDescription(
+        field: String,
+        description: String?,
+    ) = description?.validateLength("$field.description", MIN_DESCRIPTION_LENGTH, MAX_DESCRIPTION_LENGTH)
+}

--- a/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
@@ -1,10 +1,10 @@
 package com.quri.management.api.validation.bill
 
-import com.quri.client.model.BillStatus
 import com.quri.client.model.CreateBillInput
 import com.quri.management.api.validation.Validator
-import com.quri.management.api.validation.require
-import com.quri.management.api.validation.validateLength
+import com.quri.management.api.validation.bill.BillValidation.validateDescription
+import com.quri.management.api.validation.bill.BillValidation.validateName
+import com.quri.management.api.validation.bill.BillValidation.validateStatusOnCreate
 import org.springframework.stereotype.Component
 
 @Component
@@ -13,19 +13,8 @@ class CreateBillValidator : Validator<CreateBillInput> {
         field: String,
         input: CreateBillInput,
     ) {
-        input.name?.validateLength("$field.name", MIN_BILL_NAME_LENGTH, MAX_BILL_NAME_LENGTH)
-        input.status?.let {
-            require(it == BillStatus.DRAFT || it == BillStatus.PUBLISHED) {
-                "status on bill creation must be DRAFT or PUBLISHED"
-            }
-        }
-        input.description?.validateLength("$field.description", MIN_DESCRIPTION_LENGTH, MAX_DESCRIPTION_LENGTH)
-    }
-
-    companion object {
-        private const val MIN_BILL_NAME_LENGTH = 1
-        private const val MAX_BILL_NAME_LENGTH = 32
-        private const val MIN_DESCRIPTION_LENGTH = 1
-        private const val MAX_DESCRIPTION_LENGTH = 150
+        validateName(field, input.name)
+        validateStatusOnCreate(field, input.status)
+        validateDescription(field, input.description)
     }
 }

--- a/src/main/kotlin/com/quri/management/api/validation/bill/UpdateBillValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/UpdateBillValidator.kt
@@ -1,0 +1,20 @@
+package com.quri.management.api.validation.bill
+
+import com.quri.client.model.UpdateBillInput
+import com.quri.management.api.validation.Validator
+import com.quri.management.api.validation.bill.BillValidation.validateDescription
+import com.quri.management.api.validation.bill.BillValidation.validateName
+import com.quri.management.api.validation.model.MonetaryAmountValidator
+import org.springframework.stereotype.Component
+
+@Component
+class UpdateBillValidator(private val monetaryAmountValidator: MonetaryAmountValidator) : Validator<UpdateBillInput> {
+    override suspend fun validate(
+        field: String,
+        input: UpdateBillInput,
+    ) {
+        input.name?.let { validateName(field, input.name) }
+        input.description?.let { validateDescription(field, input.description) }
+        input.balance?.let { monetaryAmountValidator.validate(field, input.balance) }
+    }
+}

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
@@ -1,16 +1,23 @@
 package com.quri.management.db.mongo.collections
 
 import com.mongodb.client.model.Filters.eq
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Updates.combine
+import com.mongodb.client.model.Updates.set
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.quri.client.model.Bill
 import com.quri.client.model.CreateBillInput
+import com.quri.client.model.UpdateBillInput
 import com.quri.management.db.mongo.MongoSchema.Collections.BILLS
 import com.quri.management.db.mongo.documents.BillDocument
 import com.quri.management.db.mongo.paginate
 import kotlinx.coroutines.flow.firstOrNull
+import org.bson.conversions.Bson
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 /**
  * Data access layer for the bills collection in MongoDB.
@@ -23,7 +30,7 @@ import org.springframework.stereotype.Component
  * @param dataStoreDatabase the MongoDB database instance injected by Spring
  */
 @Component
-class BillCollection(dataStoreDatabase: MongoDatabase) {
+class BillCollection(private val dataStoreDatabase: MongoDatabase) {
     private val collection: MongoCollection<BillDocument> =
         dataStoreDatabase.getCollection(BILLS, BillDocument::class.java)
 
@@ -58,7 +65,6 @@ class BillCollection(dataStoreDatabase: MongoDatabase) {
      *
      * @param pageSize is the maximum results per page
      * @param nextToken is the bookmarked ID the next paginated list starts from
-     *
      * @return list of all [Bill] documents mapped to Smithy models and nullable pagination token
      */
     suspend fun listAll(
@@ -77,5 +83,47 @@ class BillCollection(dataStoreDatabase: MongoDatabase) {
     suspend fun deleteById(id: ObjectId): ObjectId? {
         val result = collection.deleteOne(eq("_id", id))
         return id.takeIf { result.deletedCount == 1L }
+    }
+
+    /**
+     * Updates a bill by its [ObjectId].
+     *
+     * Combines a list of conditional updates to a single update,
+     * auditing the actor behind this modification.
+     *
+     * @param input the [UpdateBillInput] contents for updating a bill
+     * @param userId actor behind update
+     * @return updated [Bill] document, `null` if update did not go through
+     */
+    suspend fun update(
+        input: UpdateBillInput,
+        userId: String,
+    ): Bill? {
+        val filter = eq("_id", ObjectId(input.billId))
+        val updates = buildUpdates(input, userId)
+        val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+        return collection.findOneAndUpdate(filter, combine(updates), options)?.toApi()
+    }
+
+    private fun buildUpdates(
+        input: UpdateBillInput,
+        userId: String,
+    ): List<Bson> {
+        val updates = mutableListOf<Bson>()
+
+        input.name?.let { updates.add(set("name", it)) }
+        input.status?.let { updates.add(set("status", it.value)) }
+        input.isHidden?.let { updates.add(set("hidden", it)) }
+        input.description?.let { updates.add(set("description", it)) }
+        input.balance?.let { updates.add(set("balance", it)) }
+        input.receipts?.takeIf { it.isNotEmpty() }?.let {
+            // Smithy returns empty list if null
+            val objectIds = it.map { id -> ObjectId(id) }
+            updates.add(set("receipts", objectIds))
+        }
+
+        updates.add(set("updatedBy", userId))
+        updates.add(set("updatedAt", Instant.now()))
+        return updates
     }
 }

--- a/src/main/kotlin/com/quri/management/services/BillService.kt
+++ b/src/main/kotlin/com/quri/management/services/BillService.kt
@@ -6,7 +6,9 @@ import com.quri.client.model.DeleteBillInput
 import com.quri.client.model.GetBillInput
 import com.quri.client.model.InternalFailureException
 import com.quri.client.model.ResourceNotFoundException
+import com.quri.client.model.UpdateBillInput
 import com.quri.management.api.validation.bill.CreateBillValidator
+import com.quri.management.api.validation.bill.UpdateBillValidator
 import com.quri.management.db.mongo.collections.BillCollection
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
@@ -15,7 +17,11 @@ import org.springframework.stereotype.Service
  * Business logic layer for bill operations.
  */
 @Service
-class BillService(private val billCollection: BillCollection, private val createBillValidator: CreateBillValidator) {
+class BillService(
+    private val billCollection: BillCollection,
+    private val createBillValidator: CreateBillValidator,
+    private val updateBillValidator: UpdateBillValidator,
+) {
     /**
      * Retrieves a bill by its ID.
      *
@@ -72,4 +78,23 @@ class BillService(private val billCollection: BillCollection, private val create
             ?: throw ResourceNotFoundException.builder()
                 .message("Bill with ID `${input.billId}` not found")
                 .build()
+
+    /**
+     * Updates a bill with user changes.
+     *
+     * @param input contents to update bill
+     * @param userId actor behind update
+     * @return [Bill] after update
+     * @throws ResourceNotFoundException if no bill exists with the ID provided
+     */
+    suspend fun updateBill(
+        input: UpdateBillInput,
+        userId: String,
+    ): Bill {
+        updateBillValidator.validate("updateBill", input)
+        return billCollection.update(input, userId)
+            ?: throw ResourceNotFoundException.builder()
+                .message("Bill with ID `${input.billId}` not found")
+                .build()
+    }
 }


### PR DESCRIPTION
## __What__

Added the `UpdateBill` REST handler (`PUT /bills`) along with a dedicated `UpdateBillValidator`, wired validation into `BillService`, and moved the update logic from the collection layer up to the service layer. README was trimmed and the new endpoint was documented.

## __Why__

The bill lifecycle was missing an update operation — users needed a way to modify bill fields (status, description, balance, receipts, etc.) after creation. Validators were also added in the service layer before passing onto the DB layer (`BillCollection`).

## __How__

- `UpdateBill.kt` — New handler accepting `UpdateBillInput` at `PUT /bills`, delegates to `BillService.updateBill()`
- `UpdateBillValidator.kt` + `BillValidation.kt` — Reusable field-level validation for bill name, description, and status using the existing `Validator<T>` contract

## __Next__

- Consider adding `PATCH /bills/{id}` for partial updates if the full-replace `PUT` semantics prove too strict
