### PR TITLE
[FEAT](profiles): add PATCH /profiles endpoint and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All endpoints require authentication via a Clerk JWT (`Authorization: Bearer <to
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/profiles` | Create a profile |
+| `PATCH` | `/profiles` | Partially update a profile | 
 | `GET` | `/profiles/{id}` | Get a profile |
 | `GET` | `/profiles` | List all profiles |
 | `DELETE` | `/profiles/{id}` | Delete a profile |

--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/UpdateProfile.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/UpdateProfile.kt
@@ -1,0 +1,26 @@
+package com.quri.management.api.handlers.profiles
+
+import com.quri.client.model.UpdateProfileInput
+import com.quri.client.model.UpdateProfileOutput
+import com.quri.management.api.security.identity.UserIdentity
+import com.quri.management.services.ProfileService
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Handles the profile update operation.
+ */
+@RestController
+@RequestMapping("/profiles")
+class UpdateProfile(private val profileService: ProfileService, private val userIdentity: UserIdentity) {
+    @PatchMapping
+    suspend fun updateProfile(@RequestBody input: UpdateProfileInput): UpdateProfileOutput {
+        val profile = profileService.updateProfile(input, userIdentity.userId())
+
+        return UpdateProfileOutput.builder()
+            .profile(profile)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/quri/management/api/serialization/SmithyJacksonConfig.kt
+++ b/src/main/kotlin/com/quri/management/api/serialization/SmithyJacksonConfig.kt
@@ -13,8 +13,9 @@ import com.quri.client.model.Item
 import com.quri.client.model.Liable
 import com.quri.client.model.MonetaryAmount
 import com.quri.client.model.PaymentMethod
-import com.quri.client.model.ProfileLocation
 import com.quri.client.model.UpdateBillInput
+import com.quri.client.model.UpdateProfileInput
+import com.quri.client.model.UserLocation
 import com.quri.client.model.ValidationException
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
@@ -88,6 +89,9 @@ class SmithyJacksonConfig {
             builder.addMixIn(UpdateBillInput::class.java, UpdateBillInputMixin::class.java)
             builder.addMixIn(UpdateBillInput.Builder::class.java, UpdateBillInputBuilderMixin::class.java)
 
+            builder.addMixIn(UpdateProfileInput::class.java, UpdateProfileInputMixin::class.java)
+            builder.addMixIn(UpdateProfileInput.Builder::class.java, UpdateProfileInputBuilderMixin::class.java)
+
             builder.addMixIn(Address::class.java, AddressMixin::class.java)
             builder.addMixIn(Address.Builder::class.java, AddressBuilderMixin::class.java)
 
@@ -106,8 +110,8 @@ class SmithyJacksonConfig {
             builder.addMixIn(MonetaryAmount::class.java, MonetaryAmountMixin::class.java)
             builder.addMixIn(MonetaryAmount.Builder::class.java, MonetaryAmountBuilderMixin::class.java)
 
-            builder.addMixIn(ProfileLocation::class.java, ProfileLocationMixin::class.java)
-            builder.addMixIn(ProfileLocation.Builder::class.java, ProfileLocationBuilderMixin::class.java)
+            builder.addMixIn(UserLocation::class.java, ProfileLocationMixin::class.java)
+            builder.addMixIn(UserLocation.Builder::class.java, ProfileLocationBuilderMixin::class.java)
         }
 }
 
@@ -256,6 +260,9 @@ abstract class CreateReceiptInputMixin
 @JsonDeserialize(builder = UpdateBillInput.Builder::class)
 abstract class UpdateBillInputMixin
 
+@JsonDeserialize(builder = UpdateProfileInput.Builder::class)
+abstract class UpdateProfileInputMixin
+
 @JsonPOJOBuilder(withPrefix = "")
 abstract class CreateProfileInputBuilderMixin
 
@@ -267,6 +274,9 @@ abstract class CreateReceiptInputBuilderMixin
 
 @JsonPOJOBuilder(withPrefix = "")
 abstract class UpdateBillInputBuilderMixin
+
+@JsonPOJOBuilder(withPrefix = "")
+abstract class UpdateProfileInputBuilderMixin
 
 // Nested
 @JsonDeserialize(builder = Address.Builder::class)
@@ -287,7 +297,7 @@ abstract class LiableMixin
 @JsonDeserialize(builder = MonetaryAmount.Builder::class)
 abstract class MonetaryAmountMixin
 
-@JsonDeserialize(builder = ProfileLocation.Builder::class)
+@JsonDeserialize(builder = UserLocation.Builder::class)
 abstract class ProfileLocationMixin
 
 @JsonPOJOBuilder(withPrefix = "")

--- a/src/main/kotlin/com/quri/management/api/validation/Constraints.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/Constraints.kt
@@ -1,5 +1,6 @@
 package com.quri.management.api.validation
 
+import org.bson.types.ObjectId
 import java.math.BigDecimal
 import java.time.Instant
 
@@ -76,4 +77,17 @@ fun Instant?.validateTimestamp(field: String): Instant? {
     val value = validateRequired(field)
     require(value < Instant.now()) { "$field must not occur in the future" }
     return this
+}
+
+/**
+ * Validates a list of [ObjectId]s for objects referencing Mongo documents.
+ */
+fun List<String>?.validateObjectIdList(field: String): List<ObjectId> {
+    val value = validateRequired(field)
+    value.forEachIndexed { index, id ->
+        require(ObjectId.isValid(id)) {
+            "$field[$index] is not a valid ObjectId: $id"
+        }
+    }
+    return value.map(::ObjectId)
 }

--- a/src/main/kotlin/com/quri/management/api/validation/bill/BillValidation.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/BillValidation.kt
@@ -1,7 +1,7 @@
 package com.quri.management.api.validation.bill
 
-import com.quri.client.model.BillStatus
 import com.quri.management.api.validation.validateLength
+import com.quri.management.api.validation.validateObjectIdList
 
 object BillValidation {
     const val MIN_NAME_LENGTH = 1
@@ -11,20 +11,16 @@ object BillValidation {
 
     fun validateName(
         field: String,
-        name: String?,
-    ) = name?.validateLength("$field.name", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
-
-    fun validateStatusOnCreate(
-        field: String,
-        status: BillStatus?,
-    ) = status?.let {
-        require(it == BillStatus.DRAFT || it == BillStatus.PUBLISHED) {
-            "$field.status status on creation must be DRAFT or PUBLISHED"
-        }
-    }
+        name: String,
+    ) = name.validateLength("$field.name", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
 
     fun validateDescription(
         field: String,
-        description: String?,
-    ) = description?.validateLength("$field.description", MIN_DESCRIPTION_LENGTH, MAX_DESCRIPTION_LENGTH)
+        description: String,
+    ) = description.validateLength("$field.description", MIN_DESCRIPTION_LENGTH, MAX_DESCRIPTION_LENGTH)
+
+    fun validateReceiptIdList(
+        field: String,
+        receipts: List<String>,
+    ) = receipts.validateObjectIdList("$field.receipts")
 }

--- a/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/CreateBillValidator.kt
@@ -1,10 +1,10 @@
 package com.quri.management.api.validation.bill
 
+import com.quri.client.model.BillStatus
 import com.quri.client.model.CreateBillInput
 import com.quri.management.api.validation.Validator
 import com.quri.management.api.validation.bill.BillValidation.validateDescription
 import com.quri.management.api.validation.bill.BillValidation.validateName
-import com.quri.management.api.validation.bill.BillValidation.validateStatusOnCreate
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,7 +14,10 @@ class CreateBillValidator : Validator<CreateBillInput> {
         input: CreateBillInput,
     ) {
         validateName(field, input.name)
-        validateStatusOnCreate(field, input.status)
         validateDescription(field, input.description)
+
+        require(input.status == BillStatus.DRAFT || input.status == BillStatus.PUBLISHED) {
+            "$field.status status on creation must be DRAFT or PUBLISHED"
+        }
     }
 }

--- a/src/main/kotlin/com/quri/management/api/validation/bill/UpdateBillValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/bill/UpdateBillValidator.kt
@@ -4,6 +4,7 @@ import com.quri.client.model.UpdateBillInput
 import com.quri.management.api.validation.Validator
 import com.quri.management.api.validation.bill.BillValidation.validateDescription
 import com.quri.management.api.validation.bill.BillValidation.validateName
+import com.quri.management.api.validation.bill.BillValidation.validateReceiptIdList
 import com.quri.management.api.validation.model.MonetaryAmountValidator
 import org.springframework.stereotype.Component
 
@@ -16,5 +17,6 @@ class UpdateBillValidator(private val monetaryAmountValidator: MonetaryAmountVal
         input.name?.let { validateName(field, input.name) }
         input.description?.let { validateDescription(field, input.description) }
         input.balance?.let { monetaryAmountValidator.validate(field, input.balance) }
+        input.receipts?.let { validateReceiptIdList(field, input.receipts) }
     }
 }

--- a/src/main/kotlin/com/quri/management/api/validation/model/AddressValidation.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/AddressValidation.kt
@@ -1,0 +1,67 @@
+package com.quri.management.api.validation.model
+
+import com.quri.management.api.validation.validateLength
+import com.quri.management.api.validation.validatePattern
+
+object AddressValidation {
+    private const val MIN_STREET_NAME_LENGTH = 1
+    private const val MAX_STREET_NAME_LENGTH = 50
+    private const val MIN_CITY_NAME_LENGTH = 1
+    private const val MAX_CITY_NAME_LENGTH = 50
+    private const val MIN_STATE_NAME_LENGTH = 1
+    private const val MAX_STATE_NAME_LENGTH = 50
+    private const val MIN_UNIT_NAME_LENGTH = 1
+    private const val MAX_UNIT_NAME_LENGTH = 10
+    private const val MIN_RAW_INPUT_LENGTH = 1
+    private const val MAX_RAW_INPUT_LENGTH = 100
+    private const val MIN_FORMATTED_LENGTH = 1
+    private const val MAX_FORMATTED_LENGTH = 200
+
+    fun validateStreet(
+        field: String,
+        street: String,
+    ) = street.validateLength("$field.street", MIN_STREET_NAME_LENGTH, MAX_STREET_NAME_LENGTH)
+
+    fun validateCity(
+        field: String,
+        city: String,
+    ) = city.validateLength("$field.city", MIN_CITY_NAME_LENGTH, MAX_CITY_NAME_LENGTH)
+
+    fun validateState(
+        field: String,
+        state: String,
+    ) = state.validateLength("$field.state", MIN_STATE_NAME_LENGTH, MAX_STATE_NAME_LENGTH)
+
+    fun validatePostalCode(
+        field: String,
+        postalCode: String,
+    ) = postalCode.validatePattern(
+        "$field.postalCode",
+        Regex("^[0-9]{5}(-[0-9]{4})?$"),
+        "must be a valid ISO 3166-1 alpha-2 zip code e.g. 20001",
+    )
+
+    fun validateCountry(
+        field: String,
+        country: String,
+    ) = country.validatePattern(
+        "$field.country",
+        Regex("^[A-Z]{2}$"),
+        "must be a valid ISO 3166 alpha-2 country code e.g. US",
+    )
+
+    fun validateUnit(
+        field: String,
+        unit: String,
+    ) = unit.validateLength("$field.unit", MIN_UNIT_NAME_LENGTH, MAX_UNIT_NAME_LENGTH)
+
+    fun validateRawInput(
+        field: String,
+        rawInput: String,
+    ) = rawInput.validateLength("$field.rawInput", MIN_RAW_INPUT_LENGTH, MAX_RAW_INPUT_LENGTH)
+
+    fun validateFormatted(
+        field: String,
+        formatted: String,
+    ) = formatted.validateLength("$field.formatted", MIN_FORMATTED_LENGTH, MAX_FORMATTED_LENGTH)
+}

--- a/src/main/kotlin/com/quri/management/api/validation/model/AddressValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/AddressValidator.kt
@@ -2,8 +2,14 @@ package com.quri.management.api.validation.model
 
 import com.quri.client.model.Address
 import com.quri.management.api.validation.Validator
-import com.quri.management.api.validation.validateLength
-import com.quri.management.api.validation.validatePattern
+import com.quri.management.api.validation.model.AddressValidation.validateCity
+import com.quri.management.api.validation.model.AddressValidation.validateCountry
+import com.quri.management.api.validation.model.AddressValidation.validateFormatted
+import com.quri.management.api.validation.model.AddressValidation.validatePostalCode
+import com.quri.management.api.validation.model.AddressValidation.validateRawInput
+import com.quri.management.api.validation.model.AddressValidation.validateState
+import com.quri.management.api.validation.model.AddressValidation.validateStreet
+import com.quri.management.api.validation.model.AddressValidation.validateUnit
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,36 +18,13 @@ class AddressValidator : Validator<Address> {
         field: String,
         input: Address,
     ) {
-        input.street?.validateLength("$field.street", MIN_STREET_NAME_LENGTH, MAX_STREET_NAME_LENGTH)
-        input.city?.validateLength("$field.city", MIN_CITY_NAME_LENGTH, MAX_CITY_NAME_LENGTH)
-        input.state?.validateLength("$field.state", MIN_STATE_NAME_LENGTH, MAX_STATE_NAME_LENGTH)
-        input.postalCode?.validatePattern(
-            "$field.postalCode",
-            Regex("^[0-9]{5}(-[0-9]{4})?$"),
-            "must be a valid ISO 3166-1 alpha-2 zip code e.g. 20001",
-        )
-        input.country?.validatePattern(
-            "$field.country",
-            Regex("^[A-Z]{2}$"),
-            "must be a valid ISO 3166 alpha-2 country code e.g. US",
-        )
-        input.unit?.validateLength("$field.unit", MIN_UNIT_NAME_LENGTH, MAX_UNIT_NAME_LENGTH)
-        input.rawInput?.validateLength("$field.rawInput", MIN_RAW_INPUT_LENGTH, MAX_RAW_INPUT_LENGTH)
-        input.formatted?.validateLength("$field.formatted", MIN_FORMATTED_LENGTH, MAX_FORMATTED_LENGTH)
-    }
-
-    companion object {
-        private const val MIN_STREET_NAME_LENGTH = 1
-        private const val MAX_STREET_NAME_LENGTH = 50
-        private const val MIN_CITY_NAME_LENGTH = 1
-        private const val MAX_CITY_NAME_LENGTH = 50
-        private const val MIN_STATE_NAME_LENGTH = 1
-        private const val MAX_STATE_NAME_LENGTH = 50
-        private const val MIN_UNIT_NAME_LENGTH = 1
-        private const val MAX_UNIT_NAME_LENGTH = 10
-        private const val MIN_RAW_INPUT_LENGTH = 1
-        private const val MAX_RAW_INPUT_LENGTH = 100
-        private const val MIN_FORMATTED_LENGTH = 1
-        private const val MAX_FORMATTED_LENGTH = 200
+        validateStreet(field, input.street)
+        validateCity(field, input.city)
+        validateState(field, input.state)
+        validatePostalCode(field, input.postalCode)
+        validateCountry(field, input.country)
+        validateUnit(field, input.unit)
+        validateRawInput(field, input.rawInput)
+        validateFormatted(field, input.formatted)
     }
 }

--- a/src/main/kotlin/com/quri/management/api/validation/model/UserLocationValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/UserLocationValidator.kt
@@ -1,0 +1,20 @@
+package com.quri.management.api.validation.model
+
+import com.quri.client.model.UserLocation
+import com.quri.management.api.validation.Validator
+import com.quri.management.api.validation.model.AddressValidation.validateCity
+import com.quri.management.api.validation.model.AddressValidation.validateCountry
+import com.quri.management.api.validation.model.AddressValidation.validateState
+import org.springframework.stereotype.Component
+
+@Component
+class UserLocationValidator : Validator<UserLocation> {
+    override suspend fun validate(
+        field: String,
+        input: UserLocation,
+    ) {
+        validateCity(field, input.city)
+        validateState(field, input.state)
+        validateCountry(field, input.country)
+    }
+}

--- a/src/main/kotlin/com/quri/management/api/validation/profile/ProfileValidation.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/profile/ProfileValidation.kt
@@ -1,0 +1,51 @@
+package com.quri.management.api.validation.profile
+
+import com.quri.management.api.validation.validateLength
+import com.quri.management.api.validation.validateObjectIdList
+import com.quri.management.api.validation.validatePattern
+import com.quri.management.api.validation.validateTimestamp
+import java.time.Instant
+
+object ProfileValidation {
+    const val MIN_USERNAME_LENGTH = 3
+    const val MAX_USERNAME_LENGTH = 30
+    const val MIN_NAME_LENGTH = 1
+    const val MAX_NAME_LENGTH = 50
+    const val MIN_BIO_LENGTH = 1
+    const val MAX_BIO_LENGTH = 150
+
+    fun validateUsername(
+        field: String,
+        username: String,
+    ) = username.validateLength("$field.username", MIN_USERNAME_LENGTH, MAX_USERNAME_LENGTH)
+
+    fun validateName(
+        field: String,
+        name: String,
+    ) = name.validateLength("$field.name", MIN_NAME_LENGTH, MAX_NAME_LENGTH)
+
+    fun validateEmail(
+        field: String,
+        email: String,
+    ) = email.validatePattern("$field.email", Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"), "Invalid email format")
+
+    fun validatePhoneNumber(
+        field: String,
+        phoneNumber: String,
+    ) = phoneNumber.validatePattern("$field.phoneNumber", Regex("^[+0-9()\\-\\s]{10,20}$"), "Invalid phone number")
+
+    fun validateDateOfBirth(
+        field: String,
+        dateOfBirth: Instant,
+    ) = dateOfBirth.validateTimestamp("$field.dateOfBirth")
+
+    fun validateBio(
+        field: String,
+        bio: String,
+    ) = bio.validateLength("$field.bio", MIN_BIO_LENGTH, MAX_BIO_LENGTH)
+
+    fun validateUserIdList(
+        field: String,
+        userIds: List<String>,
+    ) = userIds.validateObjectIdList(field)
+}

--- a/src/main/kotlin/com/quri/management/api/validation/profile/UpdateProfileValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/profile/UpdateProfileValidator.kt
@@ -1,36 +1,31 @@
 package com.quri.management.api.validation.profile
 
-import com.mongodb.client.model.Filters.eq
-import com.quri.client.model.CreateProfileInput
-import com.quri.client.model.ValidationException
+import com.quri.client.model.UpdateProfileInput
 import com.quri.management.api.validation.Validator
-import com.quri.management.api.validation.profile.ProfileValidation.validateDateOfBirth
+import com.quri.management.api.validation.model.UserLocationValidator
+import com.quri.management.api.validation.profile.ProfileValidation.validateBio
 import com.quri.management.api.validation.profile.ProfileValidation.validateEmail
 import com.quri.management.api.validation.profile.ProfileValidation.validateName
 import com.quri.management.api.validation.profile.ProfileValidation.validatePhoneNumber
+import com.quri.management.api.validation.profile.ProfileValidation.validateUserIdList
 import com.quri.management.api.validation.profile.ProfileValidation.validateUsername
-import com.quri.management.db.mongo.collections.ProfileCollection
-import com.quri.management.db.mongo.documents.ProfileDocument
 import org.springframework.stereotype.Component
 
 @Component
-class CreateProfileValidator(private val profileCollection: ProfileCollection) : Validator<CreateProfileInput> {
+class UpdateProfileValidator(private val userLocationValidator: UserLocationValidator) : Validator<UpdateProfileInput> {
     override suspend fun validate(
         field: String,
-        input: CreateProfileInput,
+        input: UpdateProfileInput,
     ) {
         input.username?.let { validateUsername(field, it) }
         input.firstName?.let { validateName("$field.first", it) }
         input.lastName?.let { validateName("$field.last", it) }
         input.email?.let { validateEmail(field, it) }
-        input.dateOfBirth?.let { validateDateOfBirth(field, it) }
         input.middleName?.let { validateName("$field.middle", it) }
         input.phoneNumber?.let { validatePhoneNumber(field, it) }
-
-        require(!profileCollection.exists(eq(ProfileDocument::email.name, input.email))) {
-            throw ValidationException.builder()
-                .message("A profile with email '${input.email}' already exists")
-                .build()
-        }
+        input.bio?.let { validateBio(field, it) }
+        input.following?.let { validateUserIdList("$field.following", it) }
+        input.followers?.let { validateUserIdList("$field.followers", it) }
+        input.location?.let { userLocationValidator.validate("$field.location", it) }
     }
 }

--- a/src/main/kotlin/com/quri/management/clients/MongoClientProvider.kt
+++ b/src/main/kotlin/com/quri/management/clients/MongoClientProvider.kt
@@ -9,7 +9,7 @@ import com.quri.management.db.mongo.codecs.FeeCodec
 import com.quri.management.db.mongo.codecs.ItemCodec
 import com.quri.management.db.mongo.codecs.LiableCodec
 import com.quri.management.db.mongo.codecs.MonetaryAmountCodec
-import com.quri.management.db.mongo.codecs.ProfileLocationCodec
+import com.quri.management.db.mongo.codecs.UserLocationCodec
 import org.bson.codecs.configuration.CodecRegistries
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -53,7 +53,7 @@ class MongoClientProvider {
                 FeeCodec(monetaryAmountCodec),
                 ItemCodec(monetaryAmountCodec, liableCodec, discountCodec),
                 monetaryAmountCodec,
-                ProfileLocationCodec(),
+                UserLocationCodec(),
             ),
             MongoClientSettings.getDefaultCodecRegistry(),
         )

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/UserLocationCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/UserLocationCodec.kt
@@ -1,6 +1,6 @@
 package com.quri.management.db.mongo.codecs
 
-import com.quri.client.model.ProfileLocation
+import com.quri.client.model.UserLocation
 import org.bson.BsonReader
 import org.bson.BsonType
 import org.bson.BsonWriter
@@ -8,13 +8,13 @@ import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 
-class ProfileLocationCodec : Codec<ProfileLocation> {
+class UserLocationCodec : Codec<UserLocation> {
 
-    override fun getEncoderClass(): Class<ProfileLocation> = ProfileLocation::class.java
+    override fun getEncoderClass(): Class<UserLocation> = UserLocation::class.java
 
     override fun encode(
         writer: BsonWriter,
-        value: ProfileLocation,
+        value: UserLocation,
         encoderContext: EncoderContext,
     ) {
         writer.writeStartDocument()
@@ -27,7 +27,7 @@ class ProfileLocationCodec : Codec<ProfileLocation> {
     override fun decode(
         reader: BsonReader,
         decoderContext: DecoderContext,
-    ): ProfileLocation {
+    ): UserLocation {
         var city: String? = null
         var state: String? = null
         var country: String? = null
@@ -42,7 +42,7 @@ class ProfileLocationCodec : Codec<ProfileLocation> {
         }
         reader.readEndDocument()
 
-        return ProfileLocation.builder()
+        return UserLocation.builder()
             .city(city!!)
             .state(state!!)
             .country(country!!)

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -1,10 +1,15 @@
 package com.quri.management.db.mongo.collections
 
 import com.mongodb.client.model.Filters.eq
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Updates.combine
+import com.mongodb.client.model.Updates.set
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.Profile
+import com.quri.client.model.UpdateProfileInput
 import com.quri.management.db.mongo.MongoSchema.Collections.PROFILES
 import com.quri.management.db.mongo.documents.ProfileDocument
 import com.quri.management.db.mongo.paginate
@@ -12,6 +17,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import org.bson.conversions.Bson
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 /**
  * Data access layer for the profiles collection in MongoDB.
@@ -87,4 +93,53 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
      * @return true if at least one document matches the filter, false otherwise
      */
     suspend fun exists(filter: Bson): Boolean = collection.find(filter).limit(1).firstOrNull() != null
+
+    /**
+     * Updates a profile by its [ObjectId].
+     *
+     * Combines a list of conditional updates into a single update,
+     * auditing the actor behind the modification.
+     *
+     * @param input the [UpdateProfileInput] contents for updating a profile
+     * @param userId actor behind update
+     * @return updated [Profile] document, `null` if update was not successful.
+     */
+    suspend fun update(
+        input: UpdateProfileInput,
+        userId: String,
+    ): Profile? {
+        val filter = eq("_id", ObjectId(input.profileId))
+        val updates = buildUpdates(input, userId)
+        val options = FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER)
+        return collection.findOneAndUpdate(filter, combine(updates), options)?.toApi()
+    }
+
+    private fun buildUpdates(
+        input: UpdateProfileInput,
+        userId: String,
+    ): List<Bson> {
+        val updates = mutableListOf<Bson>()
+
+        input.username?.let { updates.add(set("username", it)) }
+        input.firstName?.let { updates.add(set("firstName", it)) }
+        input.lastName?.let { updates.add(set("lastName", it)) }
+        input.email?.let { updates.add(set("email", it)) }
+        input.middleName?.let { updates.add(set("middleName", it)) }
+        input.phoneNumber?.let { updates.add(set("phoneNumber", it)) }
+        input.bio?.let { updates.add(set("bio", it)) }
+        input.following?.takeIf { it.isNotEmpty() }?.let {
+            val objectIds = it.map { id -> ObjectId(id) }
+            updates.add(set("following", objectIds))
+        }
+        input.followers?.takeIf { it.isNotEmpty() }?.let {
+            val objectIds = it.map { id -> ObjectId(id) }
+            updates.add(set("followers", objectIds))
+        }
+        input.gender?.let { updates.add(set("gender", it.value)) }
+        input.location?.let { updates.add(set("location", it)) }
+
+        updates.add(set("updatedBy", userId))
+        updates.add(set("updatedAt", Instant.now()))
+        return updates
+    }
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/BillDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/BillDocument.kt
@@ -36,7 +36,7 @@ data class BillDocument(
             .hidden(hidden)
             .description(description)
             .balance(balance)
-            .receipts(receipts?.map { it.toString() })
+            .receipts(receipts?.map(ObjectId::toHexString))
             .createdBy(createdBy)
             .createdAt(createdAt)
             .updatedBy(updatedBy)

--- a/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/documents/ProfileDocument.kt
@@ -3,7 +3,7 @@ package com.quri.management.db.mongo.documents
 import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.Gender
 import com.quri.client.model.Profile
-import com.quri.client.model.ProfileLocation
+import com.quri.client.model.UserLocation
 import org.bson.codecs.pojo.annotations.BsonId
 import org.bson.types.ObjectId
 import java.time.Instant
@@ -20,14 +20,14 @@ data class ProfileDocument(
     val lastName: String,
     val email: String,
 
-    val following: List<String>? = emptyList(),
-    val followers: List<String>? = emptyList(),
+    val following: List<ObjectId>? = emptyList(),
+    val followers: List<ObjectId>? = emptyList(),
     val middleName: String? = null,
     val phoneNumber: String? = null,
     val bio: String? = null,
     val gender: String? = null,
     val dateOfBirth: Instant? = null,
-    val location: ProfileLocation? = null,
+    val location: UserLocation? = null,
 
     val createdBy: String,
     val createdAt: Instant,
@@ -41,8 +41,8 @@ data class ProfileDocument(
             .firstName(firstName)
             .lastName(lastName)
             .email(email)
-            .following(following)
-            .followers(followers)
+            .following(following?.map(ObjectId::toHexString))
+            .followers(followers?.map(ObjectId::toHexString))
             .middleName(middleName)
             .phoneNumber(phoneNumber)
             .bio(bio)
@@ -66,6 +66,7 @@ data class ProfileDocument(
                 firstName = input.firstName,
                 lastName = input.lastName,
                 email = input.email,
+                dateOfBirth = input.dateOfBirth,
                 middleName = input.middleName,
                 phoneNumber = input.phoneNumber,
                 createdBy = ownerId,

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -6,7 +6,9 @@ import com.quri.client.model.GetProfileInput
 import com.quri.client.model.InternalFailureException
 import com.quri.client.model.Profile
 import com.quri.client.model.ResourceNotFoundException
+import com.quri.client.model.UpdateProfileInput
 import com.quri.management.api.validation.profile.CreateProfileValidator
+import com.quri.management.api.validation.profile.UpdateProfileValidator
 import com.quri.management.db.mongo.collections.ProfileCollection
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service
 class ProfileService(
     private val profileCollection: ProfileCollection,
     private val createProfileValidator: CreateProfileValidator,
+    private val updateProfileValidator: UpdateProfileValidator,
 ) {
 
     /**
@@ -76,4 +79,23 @@ class ProfileService(
             ?: throw ResourceNotFoundException.builder()
                 .message("Profile with ID `${input.profileId}` not found")
                 .build()
+
+    /**
+     * Updates a profile with user selected user changes.
+     *
+     * @param input contents to update profile
+     * @param userId actor behind update
+     * @return [Profile] after update
+     * @throws ResourceNotFoundException if no profile exists with the ID provided
+     */
+    suspend fun updateProfile(
+        input: UpdateProfileInput,
+        userId: String,
+    ): Profile {
+        updateProfileValidator.validate("updateProfile", input)
+        return profileCollection.update(input, userId)
+            ?: throw ResourceNotFoundException.builder()
+                .message("Profile with ID `${input.profileId}` not found")
+                .build()
+    }
 }


### PR DESCRIPTION
__What__

Implemented a `PATCH /profiles` endpoint with full validation, service, and persistence support. Also refactored Bill validation (inlined status check, added receiptId list validation), renamed `ProfileLocation` → `UserLocation` across the codebase, and fixed a type bug in `following`/`followers` (now stored as `ObjectId` instead of `String`).

---

__Why__

Profiles needed an update path — previously the handler, validator, and collection `update` method were all missing. The `ProfileLocation → UserLocation` rename aligns with a Smithy model change in QuriModels, where the shape was generalized beyond profile usage. Bill validation was cleaned up: the `validateStatusOnCreate` check was unnecessarily abstracted into a separate function (now inline in the validator), and receiptId validation was needed for the bill-receipt association feature. The `following`/`followers` type bug surfaced during this work — storing raw strings instead of `ObjectId` would have caused downstream lookups to fail.

---

__How__

- Created `UpdateProfile` handler with `@PatchMapping` targeting `/profiles`, consuming `UpdateProfileInput` and returning `UpdateProfileOutput` — mirrors the existing `UpdateBill` pattern for consistency
- Built `UpdateProfileValidator` that validates each optional field via dedicated methods in `ProfileValidation`, leveraging shared constraints (`validateLength`, `validatePattern`, `validateObjectIdList`) from `Constraints.kt`
- Added `ProfileCollection.update()` using `FindOneAndUpdate` with `ReturnDocument.AFTER` and a dynamic `buildUpdates()` that maps optional `UpdateProfileInput` fields to MongoDB `set()` operators plus audit fields (`updatedBy`, `updatedAt`)
- Changed `ProfileDocument.following`/`followers` from `List<String>` to `List<ObjectId>`, mapping to/from hex strings via `ObjectId::toHexString` in `toApi()`
- Replaced `ProfileLocation` references with `UserLocation` in codec (`UserLocationCodec`), `ProfileDocument`, `SmithyJacksonConfig` mixins, and `MongoClientProvider` registration — a mechanical rename across 5 files
- Created `validateObjectIdList` in `Constraints.kt` to validate and convert a list of hex strings to `ObjectId`, applied to bill `receipts` and profile `following`/`followers`
- Inlined the `BillStatus` check from `validateStatusOnCreate` directly into `CreateBillValidator.validate()` — the extracted function added indirection for a single conditional with no reuse

---

__Next__

1. Wire the `PATCH /profiles` endpoint into the API docs (README.md) with a request/response example
2. Add integration tests for the profile update flow, especially the partial-update (PATCH) semantics
3. Consider adding a `PUT /profiles/{id}` for full replacement if the use case arises
