### PR TITLE
[REFACT]: add profile and bill ID to URI as path variables

### DIFF
--- a/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bills/UpdateBill.kt
@@ -5,6 +5,7 @@ import com.quri.client.model.UpdateBillOutput
 import com.quri.management.api.security.identity.UserIdentity
 import com.quri.management.services.BillService
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -13,10 +14,17 @@ import org.springframework.web.bind.annotation.RestController
  * Handles the bill update operation.
  */
 @RestController
-@RequestMapping("/bills")
+@RequestMapping("/bills{billId}")
 class UpdateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
     @PatchMapping
-    suspend fun updateBill(@RequestBody input: UpdateBillInput): UpdateBillOutput {
+    suspend fun updateBill(
+        @PathVariable billId: String,
+        @RequestBody input: UpdateBillInput,
+    ): UpdateBillOutput {
+        val input = input.toBuilder()
+            .billId(billId)
+            .build()
+
         val bill = billService.updateBill(input, userIdentity.userId())
 
         return UpdateBillOutput.builder()

--- a/src/main/kotlin/com/quri/management/api/handlers/profiles/UpdateProfile.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/profiles/UpdateProfile.kt
@@ -5,6 +5,7 @@ import com.quri.client.model.UpdateProfileOutput
 import com.quri.management.api.security.identity.UserIdentity
 import com.quri.management.services.ProfileService
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -13,10 +14,17 @@ import org.springframework.web.bind.annotation.RestController
  * Handles the profile update operation.
  */
 @RestController
-@RequestMapping("/profiles")
+@RequestMapping("/profiles/{profileId}")
 class UpdateProfile(private val profileService: ProfileService, private val userIdentity: UserIdentity) {
     @PatchMapping
-    suspend fun updateProfile(@RequestBody input: UpdateProfileInput): UpdateProfileOutput {
+    suspend fun updateProfile(
+        @PathVariable profileId: String,
+        @RequestBody input: UpdateProfileInput,
+    ): UpdateProfileOutput {
+        val input = input.toBuilder()
+            .profileId(profileId)
+            .build()
+
         val profile = profileService.updateProfile(input, userIdentity.userId())
 
         return UpdateProfileOutput.builder()


### PR DESCRIPTION
Per standard RFC 7231, we should make these operations target the resource we modify, it is necessary for rate limiting and consistency within our system.

> Slight caveat that users must at least include the `receiptId` or `billId` in the request body, this field is ignored and the path variable is the only source of truth.