### PR TITLE
[TEST](billService): add coverage for bill service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ tasks.withType<Detekt>().configureEach {
 }
 
 // ── Test ──────────────────────────────────────────────────────────────────────
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
 	useJUnitPlatform()
 }
 

--- a/src/main/kotlin/com/quri/management/api/handlers/bills/DeleteBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bills/DeleteBill.kt
@@ -23,7 +23,7 @@ class DeleteBill(private val billService: BillService) {
         val deletedBillId = billService.deleteBill(input)
 
         return DeleteBillOutput.builder()
-            .billId(deletedBillId)
+            .billId(deletedBillId.toString())
             .build()
     }
 }

--- a/src/main/kotlin/com/quri/management/services/BillService.kt
+++ b/src/main/kotlin/com/quri/management/services/BillService.kt
@@ -73,8 +73,8 @@ class BillService(
      * @return the deleted bill ID
      * @throws ResourceNotFoundException if no bill exists with the ID provided
      */
-    suspend fun deleteBill(input: DeleteBillInput): String =
-        billCollection.deleteById(ObjectId(input.billId))?.toString()
+    suspend fun deleteBill(input: DeleteBillInput): ObjectId =
+        billCollection.deleteById(ObjectId(input.billId))
             ?: throw ResourceNotFoundException.builder()
                 .message("Bill with ID `${input.billId}` not found")
                 .build()

--- a/src/test/kotlin/com/quri/management/fixtures/BillFixtures.kt
+++ b/src/test/kotlin/com/quri/management/fixtures/BillFixtures.kt
@@ -1,0 +1,87 @@
+package com.quri.management.fixtures
+
+import com.quri.client.model.Bill
+import com.quri.client.model.BillStatus
+import com.quri.client.model.CreateBillInput
+import com.quri.client.model.DeleteBillInput
+import com.quri.client.model.GetBillInput
+import com.quri.client.model.MonetaryAmount
+import com.quri.client.model.UpdateBillInput
+import org.bson.types.ObjectId
+import java.time.Instant
+
+object BillFixtures {
+
+    val DEFAULT_BILL_ID = ObjectId().toString()
+    const val DEFAULT_OWNER_ID = "owner-1"
+    const val DEFAULT_USER_ID = "user-1"
+
+    fun aBill(
+        id: String = DEFAULT_BILL_ID,
+        name: String = "Test Bill",
+        status: BillStatus = BillStatus.DRAFT,
+        hidden: Boolean = false,
+        description: String? = null,
+        balance: MonetaryAmount? = null,
+        receipts: List<String>? = null,
+        createdAt: Instant = Instant.parse("2024-01-01T00:00:00Z"),
+        createdBy: String = DEFAULT_USER_ID,
+        updatedAt: Instant = Instant.parse("2024-01-01T00:00:00Z"),
+        updatedBy: String = DEFAULT_USER_ID,
+    ): Bill =
+        Bill.builder()
+            .id(id)
+            .name(name)
+            .status(status)
+            .hidden(hidden)
+            .createdAt(createdAt)
+            .createdBy(createdBy)
+            .updatedAt(updatedAt)
+            .updatedBy(updatedBy)
+            .apply { description?.let { description(it) } }
+            .apply { balance?.let { balance(it) } }
+            .apply { receipts?.let { receipts(it) } }
+            .build()
+
+    fun aCreateBillInput(
+        name: String = "Test Bill",
+        status: BillStatus = BillStatus.DRAFT,
+        hidden: Boolean = false,
+        description: String? = null,
+    ): CreateBillInput =
+        CreateBillInput.builder()
+            .name(name)
+            .status(status)
+            .hidden(hidden)
+            .apply { description?.let { description(it) } }
+            .build()
+
+    fun aGetBillInput(billId: String = DEFAULT_BILL_ID): GetBillInput =
+        GetBillInput.builder()
+            .billId(billId)
+            .build()
+
+    fun aDeleteBillInput(billId: String = DEFAULT_BILL_ID): DeleteBillInput =
+        DeleteBillInput.builder()
+            .billId(billId)
+            .build()
+
+    fun anUpdateBillInput(
+        billId: String = DEFAULT_BILL_ID,
+        name: String? = null,
+        status: BillStatus? = null,
+        hidden: Boolean? = null,
+        description: String? = null,
+        balance: MonetaryAmount? = null,
+        receipts: List<String>? = null,
+    ): UpdateBillInput =
+        UpdateBillInput.builder()
+            .billId(billId)
+            .apply { status?.let { status(it) } }
+            .apply { name?.let { name(it) } }
+            .apply { hidden?.let { hidden(it) } }
+            .apply { description?.let { description(it) } }
+            .apply { balance?.let { balance(it) } }
+            .apply { receipts?.let { receipts(it) } }
+            .build()
+}

--- a/src/test/kotlin/com/quri/management/services/BillServiceTest.kt
+++ b/src/test/kotlin/com/quri/management/services/BillServiceTest.kt
@@ -1,0 +1,190 @@
+package com.quri.management.services
+
+import com.quri.client.model.BillStatus
+import com.quri.client.model.InternalFailureException
+import com.quri.client.model.ResourceNotFoundException
+import com.quri.management.api.validation.bill.CreateBillValidator
+import com.quri.management.api.validation.bill.UpdateBillValidator
+import com.quri.management.db.mongo.collections.BillCollection
+import com.quri.management.fixtures.BillFixtures
+import com.quri.management.fixtures.BillFixtures.DEFAULT_BILL_ID
+import com.quri.management.fixtures.BillFixtures.DEFAULT_OWNER_ID
+import com.quri.management.fixtures.BillFixtures.DEFAULT_USER_ID
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.bson.types.ObjectId
+
+@Suppress("unused")
+class BillServiceTest :
+    DescribeSpec({
+
+        val billCollection = mockk<BillCollection>()
+        val createBillValidator = mockk<CreateBillValidator>()
+        val updateBillValidator = mockk<UpdateBillValidator>()
+
+        val billService = BillService(
+            billCollection = billCollection,
+            createBillValidator = createBillValidator,
+            updateBillValidator = updateBillValidator,
+        )
+
+        afterEach { clearMocks(billCollection, createBillValidator, updateBillValidator) }
+
+        describe("getBillFromId") {
+
+            context("when a bill exists for the given ID") {
+                it("returns the matching bill") {
+                    val bill = BillFixtures.aBill()
+                    val input = BillFixtures.aGetBillInput(billId = DEFAULT_BILL_ID)
+                    coEvery { billCollection.findById(any()) } returns bill
+
+                    val result = billService.getBillFromId(input)
+
+                    result shouldBe bill
+                    coVerify(exactly = 1) { billCollection.findById(ObjectId(input.billId)) }
+                }
+            }
+
+            context("when no bill exists for the given ID") {
+                it("throws ResourceNotFoundException") {
+                    val input = BillFixtures.aGetBillInput(billId = DEFAULT_BILL_ID)
+                    coEvery { billCollection.findById(any()) } returns null
+
+                    shouldThrow<ResourceNotFoundException> {
+                        billService.getBillFromId(input)
+                    }
+                }
+            }
+        }
+
+        describe("createBill") {
+
+            context("when input is valid and collection succeeds") {
+                it("validates input, persists, and returns the created bill") {
+                    val input = BillFixtures.aCreateBillInput()
+                    val created = BillFixtures.aBill(status = BillStatus.DRAFT)
+                    coJustRun { createBillValidator.validate(any(), any()) }
+                    coEvery { billCollection.create(input, DEFAULT_OWNER_ID) } returns created
+
+                    val result = billService.createBill(input, DEFAULT_OWNER_ID)
+
+                    result shouldBe created
+                    coVerify(exactly = 1) { createBillValidator.validate("createBill", input) }
+                    coVerify(exactly = 1) { billCollection.create(input, DEFAULT_OWNER_ID) }
+                }
+            }
+
+            context("when collection returns null") {
+                it("throws InternalFailureException") {
+                    val input = BillFixtures.aCreateBillInput()
+                    coJustRun { createBillValidator.validate(any(), any()) }
+                    coEvery { billCollection.create(any(), any()) } returns null
+
+                    shouldThrow<InternalFailureException> {
+                        billService.createBill(input, DEFAULT_OWNER_ID)
+                    }
+                }
+            }
+        }
+
+        describe("listBills") {
+
+            context("when bills exist") {
+                it("returns the list and a pagination token") {
+                    val bills = listOf(BillFixtures.aBill(), BillFixtures.aBill(id = ObjectId().toString()))
+                    val nextToken = "next-page-token"
+                    coEvery { billCollection.listAll(10, null) } returns Pair(bills, nextToken)
+
+                    val (result, token) = billService.listBills(pageSize = 10, nextToken = null)
+
+                    result shouldBe bills
+                    token shouldBe nextToken
+                }
+            }
+
+            context("when no bills exist") {
+                it("returns an empty list and null token") {
+                    coEvery { billCollection.listAll(any(), any()) } returns Pair(emptyList(), null)
+
+                    val (result, token) = billService.listBills(pageSize = 10, nextToken = null)
+
+                    result shouldBe emptyList()
+                    token shouldBe null
+                }
+            }
+
+            context("when a nextToken is provided") {
+                it("passes it through to the collection") {
+                    val token = "some-cursor"
+                    coEvery { billCollection.listAll(10, token) } returns Pair(emptyList(), null)
+
+                    billService.listBills(pageSize = 10, nextToken = token)
+
+                    coVerify(exactly = 1) { billCollection.listAll(10, token) }
+                }
+            }
+        }
+
+        describe("deleteBill") {
+
+            context("when the bill exists") {
+                it("returns the deleted bill ID as a string") {
+                    val objectId = ObjectId(DEFAULT_BILL_ID)
+                    val input = BillFixtures.aDeleteBillInput(billId = DEFAULT_BILL_ID)
+                    coEvery { billCollection.deleteById(any()) } returns objectId
+
+                    val result = billService.deleteBill(input)
+
+                    result shouldBe objectId
+                }
+            }
+
+            context("when the bill does not exist") {
+                it("throws ResourceNotFoundException") {
+                    val input = BillFixtures.aDeleteBillInput(billId = DEFAULT_BILL_ID)
+                    coEvery { billCollection.deleteById(any()) } returns null
+
+                    shouldThrow<ResourceNotFoundException> {
+                        billService.deleteBill(input)
+                    }
+                }
+            }
+        }
+
+        describe("updateBill") {
+
+            context("when input is valid and bill exists") {
+                it("validates, updates, and returns the updated bill") {
+                    val input = BillFixtures.anUpdateBillInput(name = "Updated Name")
+                    val updated = BillFixtures.aBill(name = "Updated Name")
+                    coJustRun { updateBillValidator.validate(any(), any()) }
+                    coEvery { billCollection.update(input, DEFAULT_USER_ID) } returns updated
+
+                    val result = billService.updateBill(input, DEFAULT_USER_ID)
+
+                    result.name shouldBe "Updated Name"
+                    coVerify(exactly = 1) { updateBillValidator.validate("updateBill", input) }
+                }
+            }
+
+            context("when bill does not exist") {
+                it("throws ResourceNotFoundException after validation") {
+                    val input = BillFixtures.anUpdateBillInput()
+                    coJustRun { updateBillValidator.validate(any(), any()) }
+                    coEvery { billCollection.update(any(), any()) } returns null
+
+                    shouldThrow<ResourceNotFoundException> {
+                        billService.updateBill(input, DEFAULT_USER_ID)
+                    }
+
+                    coVerify(exactly = 1) { updateBillValidator.validate(any(), any()) }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
To meet the coverage requirements of 60% coming from no tests, this is the initial set of tests that will provide full coverage for our `BillService` class. It uses `MockK` and `Kotest` libraries running on top of the `JUnit 5` runner.

- removed the coroutines test package (not needed until slices)
- modified the `deleteBill` operation to return `ObjectId`, serialization was handled at the wrong layer
- `BillFixtures` provide a single file where test data can be located
- mocked db classes and stubbed with data from fixtures

<img width="1500" height="98" alt="image" src="https://github.com/user-attachments/assets/82bff75c-ff28-428c-bffd-6e39851645ce" />
