### PR TITLE
[CONFIG]: add integration test suite with TestContainer toolchain dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 	alias(libs.plugins.spring.boot)
 	alias(libs.plugins.spring.dependency)
 	alias(libs.plugins.kover)
+	idea
 }
 
 group = "com.quri"
@@ -25,11 +26,41 @@ kotlin {
 	}
 }
 
+// ── Source Sets ───────────────────────────────────────────────────────────────
+// Creates isolated source set for infra-backed integration tests
+// Inherits code boundaries + testing libraries from standard unit tests
+val integrationSourceSet = sourceSets.create("integration") {
+	kotlin {
+		compileClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+		runtimeClasspath += sourceSets.main.get().output + sourceSets.test.get().output
+	}
+}
+
+// Inherits test implementation and runtime libraries into integration suite
+configurations[integrationSourceSet.implementationConfigurationName]
+	.extendsFrom(configurations.testImplementation.get())
+configurations[integrationSourceSet.runtimeOnlyConfigurationName]
+	.extendsFrom(configurations.testRuntimeOnly.get())
+
+// Forces IntelliJ IDEA to recognize this custom set as a designated test src root
+// a.k.a. turns the folder green
+idea {
+	module {
+		testSources.from(integrationSourceSet.kotlin.srcDirs)
+		testResources.from(integrationSourceSet.resources.srcDirs)
+	}
+}
+
 // ── Detekt (static analysis + ktlint formatting) ──────────────────────────────
 // Ref: https://detekt.dev/docs/2.0.0-alpha.1/intro
 detekt {
 	config.setFrom(file("config/detekt/detekt.yml"))
 	buildUponDefaultConfig = true
+	source.from(
+		sourceSets.main.get().kotlin,
+		sourceSets.test.get().kotlin,
+		integrationSourceSet.kotlin
+	)
 }
 
 repositories {
@@ -65,15 +96,35 @@ dependencies {
 	implementation(libs.logstash.logback.encoder)
 
 	// ── Test ──────────────────────────────────────────────────────────────────
+	testImplementation(libs.spring.boot.starter.test) {
+		exclude(module = "mockito-core")
+	}
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.kotest.runner.junit5)
 	testImplementation(libs.kotest.assertions.core)
 	testImplementation(libs.kotest.property)
 	testImplementation(libs.mockk)
 
-	testImplementation(libs.spring.boot.starter.test) {
-		exclude(module = "mockito-core")
-	}
+	// ── Integration Test ──────────────────────────────────────────────────────
+	val integrationImplementation by configurations
+
+	// Support for constructor dependency injection, bridges Kotest's coroutine execution model
+	// with Spring's requirement for JUnit, enabling proper application context + caching
+	// Ref: https://kotest.io/docs/extensions/spring.html
+	integrationImplementation(libs.kotest.extensions.spring)
+
+	// Target and replace a specific Spring bean inside the active application context with MockK mock
+	// Ref: https://github.com/Ninja-Squad/springmockk
+	integrationImplementation(libs.springmockk)
+
+	// Manage services running inside containers, integrates with JUnit to start up containers before
+	// tests run and are practical for writing integration tests against a real backend service (e.g. Mongo, MySQL)
+	// Ref: https://docs.spring.io/spring-boot/reference/testing/testcontainers.html
+	integrationImplementation(libs.spring.boot.testcontainers)
+
+	// Downloads, starts, and stops genuine MongoDB service inside isolated container
+	// Ref: https://testcontainers.com/modules/mongodb/
+	integrationImplementation(libs.testcontainers.mongodb)
 
 	// ── Code Quality ──────────────────────────────────────────────────────────
 	// Ref: https://detekt.dev/docs/intro
@@ -100,17 +151,22 @@ tasks.withType<Test>().configureEach {
 	useJUnitPlatform()
 }
 
+// Registers integration test suite, runs sequentially after local unit tests have passed
+tasks.register<Test>("integration") {
+	description = "Runs integration tests against real infrastructure"
+	group = "verification"
+	testClassesDirs = integrationSourceSet.output.classesDirs
+	classpath = integrationSourceSet.runtimeClasspath
+	shouldRunAfter("test")
+}
+
 // ── Coverage ──────────────────────────────────────────────────────────────────
 kover {
 	reports {
 		total {
-			html {
-				onCheck = false
-			}
+			html { onCheck = false }
 			verify {
-				rule {
-					minBound(60)
-				}
+				rule { minBound(60) }
 			}
 		}
 		filters {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,9 +35,13 @@ logstash-logback       = "9.0"
 # ── Kotlin Ecosystem ──────────────────────────────────────────────────────────
 # reactor integration required for suspend functions in WebFlux controllers.
 kotlinx-coroutines     = "1.10.2"
-kotest                 = "6.1.9"
-mockk                  = "1.14.9"
+
+# ── Testing Ecosystem ─────────────────────────────────────────────────────────
+kotest                 = "6.1.11"
 kover                  = "0.9.8"
+mockk                  = "1.14.9"
+springmockk            = "5.0.1"
+testcontainers         = "1.20.4"
 
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -71,11 +75,17 @@ spring-boot-starter-webflux            = { module = "org.springframework.boot:sp
 # required for WebFlux to invoke suspend controller methods correctly.
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines" }
 
-# ── Testing ───────────────────────────────────────────────────────────────────
+# ── Testing (Unit Base) ───────────────────────────────────────────────────────
 kotest-runner-junit5   = { module = "io.kotest:kotest-runner-junit5",   version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-property        = { module = "io.kotest:kotest-property",        version.ref = "kotest" }
 mockk                  = { module = "io.mockk:mockk",                   version.ref = "mockk"  }
+
+# ── Testing (Integration) ─────────────────────────────────────────────────────
+kotest-extensions-spring   = { module = "io.kotest:kotest-extensions-spring", version.ref = "kotest" }
+springmockk                = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+testcontainers-mongodb     = { module = "org.testcontainers:mongodb", version.ref = "testcontainers" }
 
 # ── Database ──────────────────────────────────────────────────────────────────
 mongodb-bson-kotlinx            = { module = "org.mongodb:bson-kotlinx",                    version.ref = "mongodb" }


### PR DESCRIPTION
__What__
Added a custom `integration` Gradle source set with IntelliJ IDEA recognition, plus dependencies for Kotest Spring extensions, SpringMockK, and Testcontainers MongoDB to enable running isolated infrastructure-backed integration tests.

__Why__
Unit tests mock the MongoDB layer, leaving data-access logic and query behavior unverified. An integration suite that exercises real Mongo (via Testcontainers) catches regressions in query construction, serialization/deserialization, and cross-collection interactions before they reach production.

__How__

- Created an `integration` source set inheriting compile/runtime classpath from `main` + `test`, and wired its implementation config to extend `testImplementation` so all unit-test libraries are available without duplication

- Added the `idea` plugin block to mark integration directories as test roots, making IntelliJ recognize them as green test folders

- Registered a standalone `integration` Gradle task (group: `verification`) that runs after `test`, keeping the CI pipeline sequential

- Bumped Kotest from `6.1.9 → 6.1.11` and introduced three new dependency categories:

  - Kotest Spring extensions — constructor DI + coroutine support in `@SpringBootTest`
  - SpringMockK — selective bean replacement inside the application context
  - Testcontainers (MongoDB module) — disposable, real MongoDB instances per test class

__Next__

- Write the first integration test (e.g., `BillServiceIntegrationTest` against real Mongo)
- Add a CI step to invoke the `integration` task after unit tests pass
- Create a shared `@SpringBootTest` base class with `@Testcontainers` for reuse across integration specs
