### PR TITLE
[TEST](infra): add IntegrationTest base class and ProjectConfig

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,6 +158,7 @@ tasks.register<Test>("integration") {
 	testClassesDirs = integrationSourceSet.output.classesDirs
 	classpath = integrationSourceSet.runtimeClasspath
 	shouldRunAfter("test")
+	failOnNoDiscoveredTests = false // TODO: remove when tests exist
 }
 
 // ── Coverage ──────────────────────────────────────────────────────────────────

--- a/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
@@ -12,9 +12,8 @@ import org.testcontainers.containers.MongoDBContainer
  * and provides a shared MongoDB container via @ServiceConnection
  */
 @SpringBootTest
-@TestConfiguration
 @ActiveProfiles("integration")
-class IntegrationTest : DescribeSpec() {
+abstract class IntegrationTest : DescribeSpec() {
     companion object {
         // Starts MongoDB container before Spring context initializes.
         // @ServiceConnection auto-wires the URI into Spring properties,

--- a/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
@@ -1,0 +1,27 @@
+package com.quri.management.config
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.containers.MongoDBContainer
+
+/**
+ * Base class for all integration tests, boots the Spring context
+ * and provides a shared MongoDB container via @ServiceConnection
+ */
+@SpringBootTest
+@TestConfiguration
+@ActiveProfiles("integration")
+class IntegrationTest : DescribeSpec() {
+    companion object {
+        // Starts MongoDB container before Spring context initializes.
+        // @ServiceConnection auto-wires the URI into Spring properties,
+        // replacing manual @DynamicPropertySource configuration and single resource
+        @ServiceConnection
+        val mongo = MongoDBContainer("mongo:latest").apply {
+            start()
+        }
+    }
+}

--- a/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
@@ -2,7 +2,6 @@ package com.quri.management.config
 
 import io.kotest.core.spec.style.DescribeSpec
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.MongoDBContainer

--- a/src/integration/kotlin/com/quri/management/config/IntegrationTestProjectConfig.kt
+++ b/src/integration/kotlin/com/quri/management/config/IntegrationTestProjectConfig.kt
@@ -1,0 +1,16 @@
+package com.quri.management.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringExtension
+
+/**
+ * Global config for integration spec classes.
+ *
+ * SpringExtension requires you to activate, not active by default.
+ * Without it Kotest has no knowledge of Spring, alternatively for each class
+ * `@ApplyExtension(SpringExtension::class)` registers the extension.
+ * Ref: https://kotest.io/docs/extensions/spring.html
+ */
+class IntegrationTestProjectConfig : AbstractProjectConfig() {
+    override val extensions = listOf(SpringExtension())
+}

--- a/src/integration/resources/application-integration.yml
+++ b/src/integration/resources/application-integration.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    org.testcontainers: WARN
+    com.github.dockerjava: WARN


### PR DESCRIPTION
### What

Added the integration test scaffold: a Testcontainers-backed `IntegrationTest` base class that boots Spring with a real MongoDB container, plus a `IntegrationTestProjectConfig` that registers Kotest's `SpringExtension`.

### Why

The project had no integration test infrastructure. Without this, `BillCollection` and the other collection classes could only be tested via unit tests with mocked databases. Testcontainers provides a throwaway MongoDB instance per test run, and Spring Boot's `@ServiceConnection` wires the container's URI automatically — avoiding the old `@DynamicPropertySource` boilerplate. Kotest's `SpringExtension` is not active by default, so `IntegrationTestProjectConfig` enables it globally so every spec class doesn't need `@ApplyExtension(SpringExtension::class)`.

### How

- `IntegrationTest` extends `DescribeSpec` and is annotated `@SpringBootTest` + `@ActiveProfiles("integration")`. It starts a `MongoDBContainer("mongo:latest")` as a `companion object` so the container lives for the lifetime of the spec class.
- `IntegrationTestProjectConfig` registers `SpringExtension` via `AbstractProjectConfig.extensions`, enabling Spring DI in every integration spec without per-class annotation.
- `application-integration.yml` suppresses verbose Testcontainers / Docker-Java logs to `WARN`.

> remove the `failOnNoDiscoveredTests` field when tests are ready

### Next

1. Write `BillCollectionTest` — CRUD integration spec covering `findById`, `create`, `listAll`, `deleteById`, `update` against the real MongoDB container with `afterEach` cleanup.
2. Extract a shared fixture / builder pattern for integration test documents.
