### PR TITLE
[TEST](collections): add integration tests for Profile and Receipt

### DIFF
--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/BillCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/BillCollectionTest.kt
@@ -6,7 +6,9 @@ import com.quri.management.config.IntegrationTest
 import com.quri.management.db.mongo.MongoSchema.Collections
 import com.quri.management.db.mongo.documents.BillDocument
 import com.quri.management.fixtures.models.BillFixtures
+import com.quri.management.fixtures.models.BillFixtures.DEFAULT_BILL_ID
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -55,13 +57,14 @@ class BillCollectionTest : IntegrationTest() {
 
             context("when input is valid") {
                 it("persists and returns the bill with a generated ID") {
-                    val input = BillFixtures.aCreateBillInput(name = "Test Bill", hidden = false)
+                    val input = BillFixtures.aCreateBillInput()
 
                     val result = billCollection.create(input, "owner-1")
 
                     assertSoftly(result!!) {
                         it.id shouldNotBe null
                         it.name shouldBe "Test Bill"
+                        it.status shouldBe BillStatus.DRAFT
                         it.isHidden shouldBe false
                         it.createdBy shouldBe "owner-1"
                         it.updatedBy shouldBe "owner-1"
@@ -158,7 +161,7 @@ class BillCollectionTest : IntegrationTest() {
                         hidden = true,
                         description = "Updated Description",
                         balance = BillFixtures.aMonetaryAmount(),
-                        receipts = listOf(ObjectId().toString()),
+                        receipts = listOf(DEFAULT_BILL_ID),
                     )
 
                     val result = billCollection.update(input, "user-1")
@@ -170,7 +173,7 @@ class BillCollectionTest : IntegrationTest() {
                         it.isHidden shouldBe true
                         it.description shouldBe "Updated Description"
                         it.balance shouldBe BillFixtures.aMonetaryAmount()
-                        it.receipts shouldNotBe emptyList<ObjectId>()
+                        it.receipts shouldContain DEFAULT_BILL_ID
                         it.updatedBy shouldBe "user-1"
                         it.updatedAt shouldNotBe null
                     }

--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/ProfileCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/ProfileCollectionTest.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.bson.types.ObjectId
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 
 @Suppress("unused")
 class ProfileCollectionTest : IntegrationTest() {
@@ -67,7 +66,7 @@ class ProfileCollectionTest : IntegrationTest() {
                         it.firstName shouldBe "Test"
                         it.lastName shouldBe "User"
                         it.email shouldBe "test@quri.com"
-                        it.dateOfBirth shouldBe Instant.parse("1995-04-15T00:00:00Z")
+                        it.dateOfBirth shouldNotBe null
                         it.createdBy shouldBe "owner-1"
                         it.updatedBy shouldBe "owner-1"
                     }
@@ -228,7 +227,7 @@ class ProfileCollectionTest : IntegrationTest() {
                         it.firstName shouldBe "Test"
                         it.lastName shouldBe "User"
                         it.email shouldBe "test@quri.com"
-                        it.dateOfBirth shouldBe Instant.parse("1995-04-15T00:00:00Z")
+                        it.dateOfBirth shouldNotBe null
                         it.middleName shouldBe null
                         it.phoneNumber shouldBe null
                         it.bio shouldBe null
@@ -236,6 +235,8 @@ class ProfileCollectionTest : IntegrationTest() {
                         it.followers shouldBe emptyList<String>()
                         it.gender shouldBe null
                         it.location shouldBe null
+                        it.updatedBy shouldBe "user-1"
+                        it.updatedAt shouldNotBe null
                     }
                 }
             }

--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/ProfileCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/ProfileCollectionTest.kt
@@ -1,0 +1,252 @@
+package com.quri.management.db.mongo.collections
+
+import com.mongodb.kotlin.client.coroutine.MongoDatabase
+import com.quri.client.model.Gender
+import com.quri.management.config.IntegrationTest
+import com.quri.management.db.mongo.MongoSchema.Collections
+import com.quri.management.db.mongo.documents.ProfileDocument
+import com.quri.management.fixtures.models.ProfileFixtures
+import com.quri.management.fixtures.models.ProfileFixtures.DEFAULT_PROFILE_ID
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.bson.types.ObjectId
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
+
+@Suppress("unused")
+class ProfileCollectionTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var profileCollection: ProfileCollection
+
+    @Autowired
+    lateinit var dataStoreDatabase: MongoDatabase
+
+    init {
+        afterEach {
+            dataStoreDatabase
+                .getCollection(Collections.PROFILES, ProfileDocument::class.java)
+                .drop()
+        }
+
+        describe("findById") {
+
+            context("when a profile exists for a given ID") {
+                it("returns the matching profile") {
+                    val input = ProfileFixtures.aCreateProfileInput()
+                    val created = profileCollection.create(input, "owner-1")!!
+
+                    val result = profileCollection.findById(ObjectId(created.id))
+                    result shouldNotBe null
+                    result!!.id shouldBe created.id
+                }
+            }
+
+            context("when no profile exists for the given ID") {
+                it("returns null") {
+                    val result = profileCollection.findById(ObjectId())
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("create") {
+
+            context("input is a valid") {
+                it("persists and returns the profile with a generated ID") {
+                    val input = ProfileFixtures.aCreateProfileInput()
+
+                    val result = profileCollection.create(input, "owner-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldNotBe null
+                        it.username shouldBe "testuser"
+                        it.firstName shouldBe "Test"
+                        it.lastName shouldBe "User"
+                        it.email shouldBe "test@quri.com"
+                        it.dateOfBirth shouldBe Instant.parse("1995-04-15T00:00:00Z")
+                        it.createdBy shouldBe "owner-1"
+                        it.updatedBy shouldBe "owner-1"
+                    }
+                }
+
+                it("assigns distinct IDs to separate documents") {
+                    val first = profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1")
+                    val second = profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-2")
+
+                    first!!.id shouldNotBe second!!.id
+                }
+            }
+        }
+
+        describe("listAll") {
+
+            context("when no profiles exists") {
+                it("returns an empty list and null token") {
+                    val (results, token) = profileCollection.listAll(10, null)
+
+                    results shouldBe emptyList()
+                    token shouldBe null
+                }
+            }
+
+            context("when profiles exist within page size") {
+                it("returns all profiles and null token") {
+                    repeat(3) { profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1") }
+
+                    val (results, token) = profileCollection.listAll(10, null)
+
+                    results shouldHaveSize 3
+                    token shouldBe null
+                }
+            }
+
+            context("when profiles exceed page size") {
+                it("returns pageSize results and a pagination token") {
+                    repeat(5) { profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1") }
+
+                    val (results, token) = profileCollection.listAll(3, null)
+
+                    results shouldHaveSize 3
+                    token shouldNotBe null
+                }
+            }
+
+            context("when nextToken is provided") {
+                it("returns the next page starting after the token") {
+                    repeat(5) { profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1") }
+
+                    val (firstPage, token) = profileCollection.listAll(3, null)
+                    val (secondPage, nextToken) = profileCollection.listAll(3, token)
+
+                    firstPage shouldHaveSize 3
+                    secondPage shouldHaveSize 2
+                    nextToken shouldBe null
+                }
+            }
+        }
+
+        describe("deleteById") {
+
+            context("when the profile exists") {
+                it("removes the document and returns the ObjectId") {
+                    val created = profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1")!!
+                    val objectId = ObjectId(created.id)
+
+                    val result = profileCollection.deleteById(objectId)
+
+                    result shouldBe objectId
+                    profileCollection.findById(objectId) shouldBe null
+                }
+            }
+
+            context("when the profile does not exist") {
+                it("returns null") {
+                    val result = profileCollection.deleteById(ObjectId())
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("exists") {
+            context("when the profile exists") {
+                it("returns the profile") {
+                    val input = ProfileFixtures.aCreateProfileInput(email = "test@quri.com")
+                    val created = profileCollection.create(input, "owner-1")!!
+
+                    val result = profileCollection.existsByEmail(created.email)!!
+
+                    result shouldNotBe null
+                }
+            }
+
+            context("when the profile does not exist") {
+                it("returns null") {
+                    val input = ProfileFixtures.aCreateProfileInput(email = "test@quri.com")
+                    val created = profileCollection.create(input, "owner-1")
+
+                    val result = profileCollection.existsByEmail(email = "fake@email.com")
+
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("update") {
+
+            context("when the profile exists") {
+                it("updates specified fields and returns the updated profile") {
+                    val created = profileCollection.create(ProfileFixtures.aCreateProfileInput(), "owner-1")!!
+                    val input = ProfileFixtures.anUpdateProfileInput(
+                        id = created.id,
+                        username = "UpdatedUsername",
+                        firstName = "UpdatedFirstName",
+                        lastName = "UpdatedLastName",
+                        email = "updated@email.com",
+                        middleName = "UpdatedMiddleName",
+                        phoneNumber = "12345678910",
+                        bio = "Updated bio",
+                        following = listOf(DEFAULT_PROFILE_ID),
+                        followers = listOf(DEFAULT_PROFILE_ID),
+                        gender = Gender.PREFER_NOT_TO_SAY,
+                        location = ProfileFixtures.aUserLocation(),
+                    )
+
+                    val result = profileCollection.update(input, "user-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldBe created.id
+                        it.username shouldBe "UpdatedUsername"
+                        it.firstName shouldBe "UpdatedFirstName"
+                        it.lastName shouldBe "UpdatedLastName"
+                        it.email shouldBe "updated@email.com"
+                        it.middleName shouldBe "UpdatedMiddleName"
+                        it.phoneNumber shouldBe "12345678910"
+                        it.bio shouldBe "Updated bio"
+                        it.following shouldContain DEFAULT_PROFILE_ID
+                        it.followers shouldContain DEFAULT_PROFILE_ID
+                        it.gender shouldBe Gender.PREFER_NOT_TO_SAY
+                        it.location shouldBe ProfileFixtures.aUserLocation()
+                    }
+                }
+
+                it("leaves unspecified fields unchanged") {
+                    val created = profileCollection.create(
+                        ProfileFixtures.aCreateProfileInput(username = "OriginalUsername"),
+                        "owner-1",
+                    )!!
+                    val input = ProfileFixtures.anUpdateProfileInput(id = created.id)
+
+                    val result = profileCollection.update(input, "user-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldBe created.id
+                        it.username shouldBe "OriginalUsername"
+                        it.firstName shouldBe "Test"
+                        it.lastName shouldBe "User"
+                        it.email shouldBe "test@quri.com"
+                        it.dateOfBirth shouldBe Instant.parse("1995-04-15T00:00:00Z")
+                        it.middleName shouldBe null
+                        it.phoneNumber shouldBe null
+                        it.bio shouldBe null
+                        it.following shouldBe emptyList<String>()
+                        it.followers shouldBe emptyList<String>()
+                        it.gender shouldBe null
+                        it.location shouldBe null
+                    }
+                }
+            }
+
+            context("when the profile does not exist") {
+                it("returns null") {
+                    val input = ProfileFixtures.anUpdateProfileInput(id = ObjectId().toString())
+                    val result = profileCollection.update(input, "user-1")
+                    result shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
@@ -1,0 +1,243 @@
+package com.quri.management.db.mongo.collections
+
+import com.mongodb.kotlin.client.coroutine.MongoDatabase
+import com.quri.client.model.Fee
+import com.quri.client.model.PaymentMethod
+import com.quri.management.config.IntegrationTest
+import com.quri.management.db.mongo.MongoSchema.Collections
+import com.quri.management.db.mongo.documents.ReceiptDocument
+import com.quri.management.fixtures.models.ReceiptFixtures
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.bson.types.ObjectId
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+import java.time.Instant
+
+@Suppress("unused")
+class ReceiptCollectionTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var receiptCollection: ReceiptCollection
+
+    @Autowired
+    lateinit var dataStoreDatabase: MongoDatabase
+
+    init {
+        afterEach {
+            dataStoreDatabase
+                .getCollection(Collections.RECEIPTS, ReceiptDocument::class.java)
+                .drop()
+        }
+
+        describe("findById") {
+
+            context("when a receipt exists for the given ID") {
+                it("returns the matching receipt") {
+                    val input = ReceiptFixtures.aCreateReceiptInput()
+                    val created = receiptCollection.create(input, "owner-1")!!
+
+                    val result = receiptCollection.findById(ObjectId(created.id))
+
+                    result shouldNotBe null
+                    result!!.id shouldBe created.id
+                }
+            }
+
+            context("when no receipt exists for the given ID") {
+                it("returns null") {
+                    val result = receiptCollection.findById(ObjectId())
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("create") {
+
+            context("when input is valid") {
+                it("persists and returns the receipt with a generated ID") {
+                    val input = ReceiptFixtures.aCreateReceiptInput()
+
+                    val result = receiptCollection.create(input, "owner-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldNotBe null
+                        it.vendorName shouldBe "Test Vendor"
+                        it.items shouldContain ReceiptFixtures.anItem()
+                        it.occurredAt shouldBe Instant.parse("2024-01-01T00:00:00Z")
+                        it.paymentMethod shouldBe PaymentMethod.CREDIT
+                        it.subtotal shouldBe ReceiptFixtures.aMonetaryAmount()
+                        it.createdBy shouldBe "owner-1"
+                        it.updatedBy shouldBe "owner-1"
+                    }
+                }
+
+                it("assigns distinct IDs to separate documents") {
+                    val first = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")
+                    val second = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")
+
+                    first!!.id shouldNotBe second!!.id
+                }
+            }
+        }
+
+        describe("listAll") {
+
+            context("when no receipts exist") {
+                it("returns empty list and null token") {
+                    val (results, token) = receiptCollection.listAll(10, null)
+
+                    results shouldBe emptyList()
+                    token shouldBe null
+                }
+            }
+
+            context("when receipts exist within page size") {
+                it("returns all receipts and null token") {
+                    repeat(3) { receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1") }
+
+                    val (results, token) = receiptCollection.listAll(10, null)
+
+                    results shouldHaveSize 3
+                    token shouldBe null
+                }
+            }
+
+            context("when receipts exceed page size") {
+                it("returns pageSize results and a pagination token") {
+                    repeat(5) { receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1") }
+
+                    val (results, token) = receiptCollection.listAll(3, null)
+
+                    results shouldHaveSize 3
+                    token shouldNotBe null
+                }
+            }
+
+            context("when nextToken is provided") {
+                it("returns the next page starting after the token") {
+                    repeat(5) { receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1") }
+
+                    val (firstPage, token) = receiptCollection.listAll(3, null)
+                    val (secondPage, nextToken) = receiptCollection.listAll(3, token)
+
+                    firstPage shouldHaveSize 3
+                    secondPage shouldHaveSize 2
+                    nextToken shouldBe null
+                }
+            }
+        }
+
+        describe("deleteById") {
+
+            context("when the receipt exists") {
+                it("removes the document and returns the ObjectId") {
+                    val created = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")!!
+                    val objectId = ObjectId(created.id)
+
+                    val result = receiptCollection.deleteById(objectId)
+
+                    result shouldBe objectId
+                    receiptCollection.findById(objectId) shouldBe null
+                }
+            }
+
+            context("when the receipt does not exist") {
+                it("returns null") {
+                    val result = receiptCollection.deleteById(ObjectId())
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("update") {
+
+            context("when the receipt exists") {
+                it("updates specified fields and returns the updated receipt") {
+                    val created = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")!!
+                    val input = ReceiptFixtures.anUpdateReceiptInput(
+                        id = created.id,
+                        vendorName = "Updated Test Vendor",
+                        items = listOf(ReceiptFixtures.anItem()),
+                        occurredAt = Instant.parse("2024-01-01T00:00:00Z"),
+                        paymentMethod = PaymentMethod.CASH,
+                        subtotal = ReceiptFixtures.aMonetaryAmount(),
+                        tax = BigDecimal("6.90"),
+                        tip = BigDecimal("6.70"),
+                        totalSavings = ReceiptFixtures.aMonetaryAmount(),
+                        fees = listOf(ReceiptFixtures.aFee()),
+                        address = ReceiptFixtures.aValidAddress(),
+                        photoId = "https://updated.photo.id",
+                        urls = listOf("https://url.com"),
+                    )
+
+                    val result = receiptCollection.update(input, "user-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldBe created.id
+                        it.vendorName shouldBe "Updated Test Vendor"
+                        it.items shouldContain ReceiptFixtures.anItem()
+                        it.occurredAt shouldNotBe null
+                        it.paymentMethod shouldBe PaymentMethod.CASH
+                        it.subtotal shouldBe ReceiptFixtures.aMonetaryAmount()
+                        it.tax shouldBe BigDecimal("6.90")
+                        it.tip shouldBe BigDecimal("6.70")
+                        it.totalSavings shouldBe ReceiptFixtures.aMonetaryAmount()
+                        it.fees shouldContain ReceiptFixtures.aFee()
+                        it.address shouldBe ReceiptFixtures.aValidAddress()
+                        it.photoId shouldBe "https://updated.photo.id"
+                        it.urls shouldContain "https://url.com"
+                        it.updatedBy shouldBe "user-1"
+                        it.updatedAt shouldNotBe null
+                    }
+                }
+
+                it("leaves unspecified fields unchanged") {
+                    val created = receiptCollection.create(
+                        ReceiptFixtures.aCreateReceiptInput(vendorName = "Original Vendor Name"),
+                        "owner-1",
+                    )!!
+                    val input = ReceiptFixtures.anUpdateReceiptInput(
+                        id = created.id,
+                        vendorName = "Updated Vendor Name",
+                        items = created.items,
+                        occurredAt = created.occurredAt,
+                        paymentMethod = created.paymentMethod,
+                        subtotal = created.subtotal,
+                    )
+
+                    val result = receiptCollection.update(input, "user-1")
+
+                    assertSoftly(result!!) {
+                        it.id shouldBe created.id
+                        it.vendorName shouldBe "Updated Vendor Name"
+                        it.items shouldContain ReceiptFixtures.anItem()
+                        it.occurredAt shouldNotBe null
+                        it.paymentMethod shouldBe PaymentMethod.CREDIT
+                        it.subtotal shouldBe ReceiptFixtures.aMonetaryAmount()
+                        it.tax shouldBe null
+                        it.tip shouldBe null
+                        it.totalSavings shouldBe null
+                        it.fees shouldBe emptyList<Fee>()
+                        it.address shouldBe null
+                        it.photoId shouldBe null
+                        it.urls shouldBe emptyList<String>()
+                        it.updatedBy shouldBe "user-1"
+                        it.updatedAt shouldNotBe null
+                    }
+                }
+            }
+
+            context("when the receipt does not exist") {
+                it("returns null") {
+                    val input = ReceiptFixtures.anUpdateReceiptInput(id = ObjectId().toString())
+                    val result = receiptCollection.update(input, "user-1")
+                    result shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -87,12 +87,14 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
     }
 
     /**
-     * Determines if an entry in the collection exists with the given criteria.
+     * Determines if an entry in the collection exists based on email.
      *
-     * @param filter the query filter to match against (e.g., `eq("email", value)`)
      * @return true if at least one document matches the filter, false otherwise
      */
-    suspend fun exists(filter: Bson): Boolean = collection.find(filter).limit(1).firstOrNull() != null
+    suspend fun existsByEmail(email: String): Profile? {
+        val filter = eq(ProfileDocument::email.name, email)
+        return collection.find(filter).limit(1).firstOrNull()?.toApi()
+    }
 
     /**
      * Updates a profile by its [ObjectId].

--- a/src/main/kotlin/com/quri/management/services/ProfileService.kt
+++ b/src/main/kotlin/com/quri/management/services/ProfileService.kt
@@ -1,6 +1,5 @@
 package com.quri.management.services
 
-import com.mongodb.client.model.Filters.eq
 import com.quri.client.model.CreateProfileInput
 import com.quri.client.model.DeleteProfileInput
 import com.quri.client.model.GetProfileInput
@@ -12,7 +11,6 @@ import com.quri.management.api.validation.profile.CreateProfileValidator
 import com.quri.management.api.validation.profile.UpdateProfileValidator
 import com.quri.management.api.validation.require
 import com.quri.management.db.mongo.collections.ProfileCollection
-import com.quri.management.db.mongo.documents.ProfileDocument
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
@@ -53,7 +51,7 @@ class ProfileService(
     ): Profile {
         createProfileValidator.validate("createProfile", input)
 
-        require(!profileCollection.exists(eq(ProfileDocument::email.name, input.email))) {
+        require(profileCollection.existsByEmail(input.email) == null) {
             "A profile with email '${input.email}' already exists"
         }
 

--- a/src/test/kotlin/com/quri/management/fixtures/models/ReceiptFixtures.kt
+++ b/src/test/kotlin/com/quri/management/fixtures/models/ReceiptFixtures.kt
@@ -3,9 +3,11 @@ package com.quri.management.fixtures.models
 import com.quri.client.model.Address
 import com.quri.client.model.CreateReceiptInput
 import com.quri.client.model.DeleteReceiptInput
+import com.quri.client.model.Discount
 import com.quri.client.model.Fee
 import com.quri.client.model.GetReceiptInput
 import com.quri.client.model.Item
+import com.quri.client.model.Liable
 import com.quri.client.model.MonetaryAmount
 import com.quri.client.model.PaymentMethod
 import com.quri.client.model.Receipt
@@ -33,11 +35,15 @@ object ReceiptFixtures {
         name: String = "Test Item",
         units: Int = 1,
         unitCost: MonetaryAmount = aMonetaryAmount(),
+        liable: List<Liable>? = emptyList(),
+        discounts: List<Discount>? = emptyList(),
     ): Item =
         Item.builder()
             .name(name)
             .units(units)
             .unitCost(unitCost)
+            .liable(liable)
+            .discounts(discounts)
             .build()
 
     fun aFee(
@@ -126,7 +132,9 @@ object ReceiptFixtures {
         tip: BigDecimal? = null,
         totalSavings: MonetaryAmount? = null,
         fees: List<Fee>? = null,
+        address: Address? = null,
         photoId: String? = null,
+        urls: List<String>? = null,
     ): UpdateReceiptInput =
         UpdateReceiptInput.builder()
             .id(id)
@@ -139,6 +147,8 @@ object ReceiptFixtures {
             .apply { tip?.let { tip(it) } }
             .apply { totalSavings?.let { totalSavings(it) } }
             .apply { fees?.let { fees(it) } }
+            .apply { address?.let { address(it) } }
             .apply { photoId?.let { photoId(it) } }
+            .apply { urls?.let { urls(it) } }
             .build()
 }

--- a/src/test/kotlin/com/quri/management/services/ProfileServiceTest.kt
+++ b/src/test/kotlin/com/quri/management/services/ProfileServiceTest.kt
@@ -70,14 +70,14 @@ class ProfileServiceTest :
                     val created = ProfileFixtures.aProfile()
                     coJustRun { createProfileValidator.validate(any(), any()) }
                     coEvery { profileCollection.create(input, DEFAULT_OWNER_ID) } returns created
-                    coEvery { profileCollection.exists(any()) } returns false
+                    coEvery { profileCollection.existsByEmail(any()) } returns null
 
                     val result = profileService.createProfile(input, DEFAULT_OWNER_ID)
 
                     result shouldBe created
                     coVerify(exactly = 1) { createProfileValidator.validate("createProfile", input) }
                     coVerify(exactly = 1) { profileCollection.create(input, DEFAULT_OWNER_ID) }
-                    coVerify(exactly = 1) { profileCollection.exists(any()) }
+                    coVerify(exactly = 1) { profileCollection.existsByEmail(any()) }
                 }
             }
 
@@ -85,7 +85,7 @@ class ProfileServiceTest :
                 it("throws ValidationException before attempting to persist") {
                     val input = ProfileFixtures.aCreateProfileInput()
                     coJustRun { createProfileValidator.validate(any(), any()) }
-                    coEvery { profileCollection.exists(any()) } returns true
+                    coEvery { profileCollection.existsByEmail(any()) } returns ProfileFixtures.aProfile()
 
                     shouldThrow<ValidationException> {
                         profileService.createProfile(input, DEFAULT_OWNER_ID)
@@ -100,7 +100,7 @@ class ProfileServiceTest :
                     val input = ProfileFixtures.aCreateProfileInput()
                     coJustRun { createProfileValidator.validate(any(), any()) }
                     coEvery { profileCollection.create(any(), any()) } returns null
-                    coEvery { profileCollection.exists(any()) } returns false
+                    coEvery { profileCollection.existsByEmail(any()) } returns null
 
                     shouldThrow<InternalFailureException> {
                         profileService.createProfile(input, DEFAULT_OWNER_ID)


### PR DESCRIPTION
__What__
Added full integration test coverage for `ProfileCollection` and `ReceiptCollection` — covering `findById`, `create`, `listAll`, `deleteById`, and `update`. Also renamed `ProfileCollection.exists` to `existsByEmail` to improve readability.

__Why__
The collection layer previously had no integration tests, making it impossible to verify MongoDB query behavior against a real Testcontainers-backed database. The rename clarifies that the method checks email uniqueness specifically — a subtle but meaningful constraint. The BillCollection test received minor fixes to use reusable constants (`DEFAULT_BILL_ID`) and more precise matchers (`shouldContain`).

__How__

- New `ProfileCollectionTest.kt` covers all five CRUD operations with both happy-path and edge-case contexts (`profile exists` / `no profile found`, empty vs paginated `listAll`, etc.)
- New `ReceiptCollectionTest.kt` mirrors the same structure, with an additional "leaves unspecified fields unchanged" test that verifies partial updates behave correctly
- `ProfileCollection.exists` → `existsByEmail` was a single method rename cascade through `ProfileCollection`, `ProfileService`, and `ProfileServiceTest`
- `ReceiptFixtures` gained a `Discount` import to support future receipt discount tests (preparatory, not yet used)
- Test assertions that pinned `dateOfBirth` to a specific instant were relaxed to `shouldNotBe null` to reduce brittleness
