### PR TITLE
[TEST](billHandler): add coverage using WebFlux slice tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,9 @@ dependencies {
 	// Ref: https://testcontainers.com/modules/mongodb/
 	integrationImplementation(libs.testcontainers.mongodb)
 
+	// MVC related tests, tests the web controller layer
+	integrationImplementation(libs.spring.boot.starter.webflux.test)
+
 	// ── Code Quality ──────────────────────────────────────────────────────────
 	// Ref: https://detekt.dev/docs/intro
 	detektPlugins(libs.detekt.rules.ktlint.wrapper)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ spring-boot-starter-oauth2-resource-server = { module = "org.springframework.boo
 spring-boot-starter-security           = { module = "org.springframework.boot:spring-boot-starter-security"           }
 spring-boot-starter-test               = { module = "org.springframework.boot:spring-boot-starter-test"               }
 spring-boot-starter-webflux            = { module = "org.springframework.boot:spring-boot-starter-webflux"            }
+spring-boot-starter-webflux-test       = { module = "org.springframework.boot:spring-boot-starter-webflux-test"       }
 
 # ── Kotlin ────────────────────────────────────────────────────────────────────
 # kotlinx-coroutines-reactor bridges suspend functions into Reactor's Mono/Flux,

--- a/src/integration/kotlin/com/quri/management/api/handlers/BillHandlerTest.kt
+++ b/src/integration/kotlin/com/quri/management/api/handlers/BillHandlerTest.kt
@@ -1,0 +1,236 @@
+package com.quri.management.api.handlers
+
+import com.ninjasquad.springmockk.MockkBean
+import com.quri.client.model.Bill
+import com.quri.client.model.ResourceNotFoundException
+import com.quri.client.model.ValidationException
+import com.quri.management.api.handlers.bill.CreateBill
+import com.quri.management.api.handlers.bill.DeleteBill
+import com.quri.management.api.handlers.bill.GetBill
+import com.quri.management.api.handlers.bill.ListBills
+import com.quri.management.api.handlers.bill.UpdateBill
+import com.quri.management.api.security.identity.UserIdentity
+import com.quri.management.config.HandlerTest
+import com.quri.management.fixtures.models.BillFixtures
+import com.quri.management.fixtures.models.BillFixtures.DEFAULT_BILL_ID
+import com.quri.management.fixtures.models.BillFixtures.DEFAULT_USER_ID
+import com.quri.management.services.BillService
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import org.bson.types.ObjectId
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.http.MediaType
+
+@Suppress("unused")
+@WebFluxTest(
+    controllers = [CreateBill::class, DeleteBill::class, GetBill::class, ListBills::class, UpdateBill::class],
+)
+class BillHandlerTest : HandlerTest() {
+
+    @MockkBean lateinit var userIdentity: UserIdentity
+
+    @MockkBean lateinit var billService: BillService
+
+    init {
+        beforeEach {
+            coEvery { userIdentity.userId() } returns DEFAULT_USER_ID
+        }
+
+        describe("createBill") {
+
+            context("when input is valid") {
+                it("returns 201 with created bill") {
+                    coEvery { billService.createBill(any(), any()) } returns BillFixtures.aBill()
+
+                    val result = webTestClient.post()
+                        .uri("/bills")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(BillFixtures.aCreateBillInput())
+                        .exchange()
+                        .expectStatus().isCreated
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.bill.id") shouldBe DEFAULT_BILL_ID
+                    result.jsonPath("$.bill.status") shouldBe "DRAFT"
+                    result.jsonPath("$.bill.createdBy") shouldBe DEFAULT_USER_ID
+                }
+            }
+
+            context("when input is invalid") {
+                it("returns 400") {
+                    coEvery { billService.createBill(any(), any()) } throws
+                        ValidationException.builder().message("name is required").build()
+
+                    webTestClient.post()
+                        .uri("/bills")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(BillFixtures.aCreateBillInput())
+                        .exchange()
+                        .expectStatus().isBadRequest
+                }
+            }
+        }
+
+        describe("getBill") {
+
+            context("when bill exists") {
+                it("returns 200 with the bill") {
+                    coEvery { billService.getBillFromId(any()) } returns BillFixtures.aBill()
+
+                    val result = webTestClient.get()
+                        .uri("/bills/$DEFAULT_BILL_ID")
+                        .exchange()
+                        .expectStatus().isOk
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.bill.id") shouldBe DEFAULT_BILL_ID
+                    result.jsonPath("$.bill.status") shouldBe "DRAFT"
+                }
+            }
+
+            context("when bill does not exist") {
+                it("returns 404") {
+                    coEvery { billService.getBillFromId(any()) } throws
+                        ResourceNotFoundException.builder().message("bill not found").build()
+
+                    webTestClient.get()
+                        .uri("/bills/missing-id")
+                        .exchange()
+                        .expectStatus().isNotFound
+                }
+            }
+        }
+
+        describe("listBills") {
+
+            context("when called with no params") {
+                it("returns 200 with default pageSize") {
+                    coEvery { billService.listBills(pageSize = 20, nextToken = null) } returns
+                        (listOf(BillFixtures.aBill()) to null)
+
+                    val result = webTestClient.get()
+                        .uri("/bills")
+                        .exchange()
+                        .expectStatus().isOk
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.bills[0].id") shouldBe DEFAULT_BILL_ID
+                    coVerify(exactly = 1) { billService.listBills(pageSize = 20, nextToken = null) }
+                }
+            }
+
+            context("when maxResults exceeds the max page size") {
+                it("clamps to 100") {
+                    coEvery { billService.listBills(pageSize = 100, nextToken = null) } returns
+                        (emptyList<Bill>() to null)
+
+                    webTestClient.get()
+                        .uri("/bills?maxResults=9999")
+                        .exchange()
+                        .expectStatus().isOk
+
+                    coVerify(exactly = 1) { billService.listBills(pageSize = 100, nextToken = null) }
+                }
+            }
+
+            context("when maxResults is below 1") {
+                it("clamps to 1") {
+                    coEvery { billService.listBills(pageSize = 1, nextToken = null) } returns
+                        (emptyList<Bill>() to null)
+
+                    webTestClient.get()
+                        .uri("/bills?maxResults=0")
+                        .exchange()
+                        .expectStatus().isOk
+
+                    coVerify(exactly = 1) { billService.listBills(pageSize = 1, nextToken = null) }
+                }
+            }
+
+            context("when nextToken is provided") {
+                it("passes it through and returns the new token") {
+                    val token = "tok_first"
+                    coEvery { billService.listBills(pageSize = 20, nextToken = token) } returns
+                        (emptyList<Bill>() to "tok_second")
+
+                    val result = webTestClient.get()
+                        .uri("/bills?nextToken=$token")
+                        .exchange()
+                        .expectStatus().isOk
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.nextToken") shouldBe "tok_second"
+                }
+            }
+        }
+
+        describe("deleteBill") {
+
+            context("when bill exists") {
+                it("returns 200 with the deleted id") {
+                    coEvery { billService.deleteBill(any()) } returns ObjectId(DEFAULT_BILL_ID)
+
+                    val result = webTestClient.delete()
+                        .uri("/bills/$DEFAULT_BILL_ID")
+                        .exchange()
+                        .expectStatus().isOk
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.id") shouldBe DEFAULT_BILL_ID
+                }
+            }
+
+            context("when bill does not exist") {
+                it("returns 404") {
+                    coEvery { billService.deleteBill(any()) } throws
+                        ResourceNotFoundException.builder().message("bill not found").build()
+
+                    webTestClient.delete()
+                        .uri("/bills/missing-id")
+                        .exchange()
+                        .expectStatus().isNotFound
+                }
+            }
+        }
+
+        describe("updateBill") {
+
+            context("when input is valid") {
+                it("returns 200 with the updated bill") {
+                    coEvery { billService.updateBill(any(), any()) } returns BillFixtures.aBill()
+
+                    val result = webTestClient.patch()
+                        .uri("/bills/$DEFAULT_BILL_ID")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(BillFixtures.anUpdateBillInput())
+                        .exchange()
+                        .expectStatus().isOk
+                        .expectBody()
+                        .returnResult()
+
+                    result.jsonPath("$.bill.id") shouldBe DEFAULT_BILL_ID
+                }
+            }
+
+            context("when input is invalid") {
+                it("returns 400") {
+                    coEvery { billService.updateBill(any(), any()) } throws
+                        ValidationException.builder().message("invalid amount").build()
+
+                    webTestClient.patch()
+                        .uri("/bills/$DEFAULT_BILL_ID")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(BillFixtures.anUpdateBillInput())
+                        .exchange()
+                        .expectStatus().isBadRequest
+                }
+            }
+        }
+    }
+}

--- a/src/integration/kotlin/com/quri/management/api/security/TestSecurityConfig.kt
+++ b/src/integration/kotlin/com/quri/management/api/security/TestSecurityConfig.kt
@@ -1,0 +1,23 @@
+package com.quri.management.api.security
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.SecurityWebFilterChain
+
+/**
+ * Replaces the SecurityConfig in Webflux slice tests.
+ * Disables JWT authentication so handler tests focus on HTTP contract.
+ */
+@TestConfiguration
+@EnableWebFluxSecurity
+class TestSecurityConfig {
+
+    @Bean
+    fun testSecurityWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
+        http
+            .csrf { it.disable() }
+            .authorizeExchange { it.anyExchange().permitAll() }
+            .build()
+}

--- a/src/integration/kotlin/com/quri/management/api/security/TestSecurityConfig.kt
+++ b/src/integration/kotlin/com/quri/management/api/security/TestSecurityConfig.kt
@@ -2,6 +2,7 @@ package com.quri.management.api.security
 
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
@@ -10,6 +11,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain
  * Replaces the SecurityConfig in Webflux slice tests.
  * Disables JWT authentication so handler tests focus on HTTP contract.
  */
+@Profile("integration")
 @TestConfiguration
 @EnableWebFluxSecurity
 class TestSecurityConfig {

--- a/src/integration/kotlin/com/quri/management/clients/TestMongoClientProvider.kt
+++ b/src/integration/kotlin/com/quri/management/clients/TestMongoClientProvider.kt
@@ -17,8 +17,8 @@ import org.testcontainers.containers.MongoDBContainer
  */
 private val mongoContainer = MongoDBContainer("mongo:latest").apply { start() }
 
-@TestConfiguration
 @Profile("integration")
+@TestConfiguration
 class TestMongoClientProvider(private val customCodecRegistry: CodecRegistry) {
 
     /**

--- a/src/integration/kotlin/com/quri/management/clients/TestMongoClientProvider.kt
+++ b/src/integration/kotlin/com/quri/management/clients/TestMongoClientProvider.kt
@@ -19,7 +19,7 @@ private val mongoContainer = MongoDBContainer("mongo:latest").apply { start() }
 
 @TestConfiguration
 @Profile("integration")
-class MongoClientProviderTest(private val customCodecRegistry: CodecRegistry) {
+class TestMongoClientProvider(private val customCodecRegistry: CodecRegistry) {
 
     /**
      * Replaces [MongoClientProvider] in the integration profile.

--- a/src/integration/kotlin/com/quri/management/config/HandlerTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/HandlerTest.kt
@@ -15,8 +15,8 @@ import org.springframework.test.web.reactive.server.EntityExchangeResult
 import org.springframework.test.web.reactive.server.WebTestClient
 
 /**
- * Base class for handler tests.
- * SpringBoot context included with payload serialization.
+ * Base class for handler/controller tests.
+ * SpringBoot context included to mock service and auth provider.
  */
 @WebFluxTest
 @ActiveProfiles("integration")

--- a/src/integration/kotlin/com/quri/management/config/HandlerTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/HandlerTest.kt
@@ -1,0 +1,41 @@
+package com.quri.management.config
+
+import com.jayway.jsonpath.JsonPath
+import com.quri.management.api.errors.GlobalExceptionHandler
+import com.quri.management.api.security.TestSecurityConfig
+import com.quri.management.api.serialization.SmithyJacksonConfig
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.EntityExchangeResult
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * Base class for handler tests.
+ * SpringBoot context included with payload serialization.
+ */
+@WebFluxTest
+@ActiveProfiles("integration")
+@ApplyExtension(SpringExtension::class)
+@Import(
+    TestSecurityConfig::class,
+    SmithyJacksonConfig::class,
+    GlobalExceptionHandler::class,
+)
+abstract class HandlerTest : DescribeSpec() {
+
+    @Autowired
+    lateinit var webTestClient: WebTestClient
+
+    /** Reads a value from the response body at the given [path] using JSONPath syntax.
+     *
+     * @param path JSONPath expression (e.g. `$.bill.id`, `$.items[0].name`)
+     * @return the value at the given path, or throws if the path does not exist
+     */
+    fun EntityExchangeResult<ByteArray>.jsonPath(path: String) =
+        JsonPath.parse(String(responseBody!!)).read<Any>(path)!!
+}

--- a/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
+++ b/src/integration/kotlin/com/quri/management/config/IntegrationTest.kt
@@ -1,6 +1,6 @@
 package com.quri.management.config
 
-import com.quri.management.clients.MongoClientProviderTest
+import com.quri.management.clients.TestMongoClientProvider
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.extensions.spring.SpringExtension
@@ -9,13 +9,13 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 
 /**
- * Base class for all integration tests, boots the Spring context
+ * Base class for all integration tests.
  * Boots the full Spring context against a real MongoDB instance.
  */
 @SpringBootTest
 @ActiveProfiles("integration")
 @ApplyExtension(SpringExtension::class)
-@Import(MongoClientProviderTest::class)
+@Import(TestMongoClientProvider::class)
 abstract class IntegrationTest : DescribeSpec() {
     override val extensions = listOf(SpringExtension())
 }

--- a/src/integration/kotlin/com/quri/management/db/mongo/TestMongoDatabaseProvider.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/TestMongoDatabaseProvider.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Primary
  * Isolated database name prevents bleed between test runs and environments
  */
 @TestConfiguration
-class MongoDatabaseProviderTest {
+class TestMongoDatabaseProvider {
     @Bean
     @Primary
     fun mongoDatabase(mongoClient: MongoClient): MongoDatabase = mongoClient.getDatabase("quri-integration-test")

--- a/src/main/kotlin/com/quri/management/api/handlers/bill/CreateBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bill/CreateBill.kt
@@ -4,9 +4,11 @@ import com.quri.client.model.CreateBillInput
 import com.quri.client.model.CreateBillOutput
 import com.quri.management.api.security.identity.UserIdentity
 import com.quri.management.services.BillService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/bills")
 class CreateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     suspend fun createBill(@RequestBody input: CreateBillInput): CreateBillOutput {
         val bill = billService.createBill(input, userIdentity.userId())
 

--- a/src/main/kotlin/com/quri/management/api/handlers/bill/UpdateBill.kt
+++ b/src/main/kotlin/com/quri/management/api/handlers/bill/UpdateBill.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController
  * Handles the bill update operation.
  */
 @RestController
-@RequestMapping("/bills{id}")
+@RequestMapping("/bills/{id}")
 class UpdateBill(private val billService: BillService, private val userIdentity: UserIdentity) {
     @PatchMapping
     suspend fun updateBill(

--- a/src/test/kotlin/com/quri/management/fixtures/models/BillFixtures.kt
+++ b/src/test/kotlin/com/quri/management/fixtures/models/BillFixtures.kt
@@ -74,16 +74,16 @@ object BillFixtures {
         id: String = DEFAULT_BILL_ID,
         name: String? = null,
         status: BillStatus? = null,
-        hidden: Boolean? = null,
+        hidden: Boolean = false,
         description: String? = null,
         balance: MonetaryAmount? = null,
         receipts: List<String>? = null,
     ): UpdateBillInput =
         UpdateBillInput.builder()
             .id(id)
+            .hidden(hidden)
             .apply { status?.let { status(it) } }
             .apply { name?.let { name(it) } }
-            .apply { hidden?.let { hidden(it) } }
             .apply { description?.let { description(it) } }
             .apply { balance?.let { balance(it) } }
             .apply { receipts?.let { receipts(it) } }


### PR DESCRIPTION
## What

Added `@WebFluxTest`-based slice tests for all Bill CRUD endpoints, fixed the `UpdateBill` URL mapping (`/bills{id}` → `/bills/{id}`), and added `@ResponseStatus(HttpStatus.CREATED)` to `CreateBill`. Renamed test support classes (`MongoClientProviderTest` → `TestMongoClientProvider`, `MongoDatabaseProviderTest` → `TestMongoDatabaseProvider`) to clarify their role as test infrastructure rather than tests themselves.

## Why

The handler layer lacked automated HTTP contract verification — only service-level unit tests and full-stack integration tests existed, leaving a gap in testing request routing, status codes, and error mapping. The `UpdateBill` URL was broken (missing slash before path variable), and `CreateBill` returned 200 instead of 201, both of which would have been caught by a focused handler test. The test support class renames eliminate confusion between test classes and test infrastructure components.

## How

- Created `HandlerTest` base class with `@WebFluxTest`, importing `TestSecurityConfig` (disables JWT), `SmithyJacksonConfig` (Smithy JSON serialization), and `GlobalExceptionHandler` (error mapping) — the minimal slice needed to test HTTP contracts without booting the full application
- Added `jsonPath` extension on `EntityExchangeResult<ByteArray>` for readable response assertions
- `BillHandlerTest` mocks `BillService` and `UserIdentity` via `@MockkBean`, covering all 5 endpoints with happy-path and error scenarios (400, 404)
- `TestSecurityConfig` replaces the real `SecurityConfig` in the slice context, disabling CSRF and permitting all requests so tests don't need JWT tokens
- Renamed `MongoClientProviderTest` → `TestMongoClientProvider` and `MongoDatabaseProviderTest` → `TestMongoDatabaseProvider` to follow the `Test*` naming convention for `@TestConfiguration` classes, distinguishing them from actual test classes

## WebFlux vs SpringBootTest
We are only testing the REST API contract we've specified in our model, therefore we don't require spinning up Testcontainers and other beans included in the application's full context. This means that tests run a lot faster.

> For end-to-end integration testing, this will be handled once the UI has been completed.