### PR TITLE
[TEST](codec): add coverage and replace while-loop decode with sequential reads for required fields

### DIFF
--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
@@ -66,6 +66,7 @@ class ReceiptCollectionTest : IntegrationTest() {
                     assertSoftly(result!!) {
                         it.id shouldNotBe null
                         it.vendorName shouldBe "Test Vendor"
+                        it.items shouldHaveSize 1
                         it.items shouldContain ReceiptFixtures.anItem()
                         it.occurredAt shouldBe Instant.parse("2024-01-01T00:00:00Z")
                         it.paymentMethod shouldBe PaymentMethod.CREDIT
@@ -80,6 +81,22 @@ class ReceiptCollectionTest : IntegrationTest() {
                     val second = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")
 
                     first!!.id shouldNotBe second!!.id
+                }
+
+                it("round-trips nested liable and discount fields through a fresh fetch") {
+                    val input = ReceiptFixtures.aCreateReceiptInput()
+                    val created = receiptCollection.create(input, "owner-1")!!
+
+                    val fetched = receiptCollection.findById(ObjectId(created.id))!!
+
+                    assertSoftly(fetched) {
+                        it.items shouldHaveSize 1
+                        it.items[0].liable shouldHaveSize 1
+                        it.items[0].liable!![0] shouldBe ReceiptFixtures.aLiable()
+                        it.items[0].discounts shouldHaveSize 2
+                        it.items[0].discounts!![0] shouldBe ReceiptFixtures.anAmountDiscount()
+                        it.items[0].discounts!![1] shouldBe ReceiptFixtures.aRateDiscount()
+                    }
                 }
             }
         }
@@ -153,7 +170,7 @@ class ReceiptCollectionTest : IntegrationTest() {
             }
         }
 
-        describe("update") {
+        describe("update via PUT") {
 
             context("when the receipt exists") {
                 it("updates specified fields and returns the updated receipt") {
@@ -168,7 +185,7 @@ class ReceiptCollectionTest : IntegrationTest() {
                         tax = BigDecimal("6.90"),
                         tip = BigDecimal("6.70"),
                         totalSavings = ReceiptFixtures.aMonetaryAmount(),
-                        fees = listOf(ReceiptFixtures.aFee()),
+                        fees = listOf(ReceiptFixtures.aFlatFee(), ReceiptFixtures.aPercentageFee()),
                         address = ReceiptFixtures.aValidAddress(),
                         photoId = "https://updated.photo.id",
                         urls = listOf("https://url.com"),
@@ -179,6 +196,7 @@ class ReceiptCollectionTest : IntegrationTest() {
                     assertSoftly(result!!) {
                         it.id shouldBe created.id
                         it.vendorName shouldBe "Updated Test Vendor"
+                        it.items shouldHaveSize 1
                         it.items shouldContain ReceiptFixtures.anItem()
                         it.occurredAt shouldNotBe null
                         it.paymentMethod shouldBe PaymentMethod.CASH
@@ -186,7 +204,9 @@ class ReceiptCollectionTest : IntegrationTest() {
                         it.tax shouldBe BigDecimal("6.90")
                         it.tip shouldBe BigDecimal("6.70")
                         it.totalSavings shouldBe ReceiptFixtures.aMonetaryAmount()
-                        it.fees shouldContain ReceiptFixtures.aFee()
+                        it.fees shouldHaveSize 2
+                        it.fees shouldContain ReceiptFixtures.aFlatFee()
+                        it.fees shouldContain ReceiptFixtures.aPercentageFee()
                         it.address shouldBe ReceiptFixtures.aValidAddress()
                         it.photoId shouldBe "https://updated.photo.id"
                         it.urls shouldContain "https://url.com"
@@ -195,7 +215,29 @@ class ReceiptCollectionTest : IntegrationTest() {
                     }
                 }
 
-                it("leaves unspecified fields unchanged") {
+                it("omits optional fields in address") {
+                    val created = receiptCollection.create(ReceiptFixtures.aCreateReceiptInput(), "owner-1")!!
+                    val input = ReceiptFixtures.anUpdateReceiptInput(
+                        id = created.id,
+                        vendorName = created.vendorName,
+                        items = created.items,
+                        occurredAt = created.occurredAt,
+                        paymentMethod = created.paymentMethod,
+                        subtotal = created.subtotal,
+                        address = ReceiptFixtures.aMinimalAddress(),
+                    )
+
+                    val result = receiptCollection.update(input, "user-1")
+
+                    assertSoftly(result!!.address!!) {
+                        it.street shouldBe "123 Main Street"
+                        it.unit shouldBe null
+                        it.rawInput shouldBe null
+                        it.formatted shouldBe null
+                    }
+                }
+
+                it("omits all optional fields") {
                     val created = receiptCollection.create(
                         ReceiptFixtures.aCreateReceiptInput(vendorName = "Original Vendor Name"),
                         "owner-1",

--- a/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
+++ b/src/integration/kotlin/com/quri/management/db/mongo/collections/ReceiptCollectionTest.kt
@@ -92,10 +92,10 @@ class ReceiptCollectionTest : IntegrationTest() {
                     assertSoftly(fetched) {
                         it.items shouldHaveSize 1
                         it.items[0].liable shouldHaveSize 1
-                        it.items[0].liable!![0] shouldBe ReceiptFixtures.aLiable()
+                        it.items[0].liable shouldContain ReceiptFixtures.aLiable()
                         it.items[0].discounts shouldHaveSize 2
-                        it.items[0].discounts!![0] shouldBe ReceiptFixtures.anAmountDiscount()
-                        it.items[0].discounts!![1] shouldBe ReceiptFixtures.aRateDiscount()
+                        it.items[0].discounts shouldContain ReceiptFixtures.anAmountDiscount()
+                        it.items[0].discounts shouldContain ReceiptFixtures.aRateDiscount()
                     }
                 }
             }

--- a/src/main/kotlin/com/quri/management/api/validation/model/LiableValidator.kt
+++ b/src/main/kotlin/com/quri/management/api/validation/model/LiableValidator.kt
@@ -2,7 +2,6 @@ package com.quri.management.api.validation.model
 
 import com.quri.client.model.Liable
 import com.quri.management.api.validation.Validator
-import com.quri.management.api.validation.validateObjectId
 import com.quri.management.api.validation.validateRate
 import org.springframework.stereotype.Component
 
@@ -12,7 +11,6 @@ class LiableValidator : Validator<Liable> {
         field: String,
         input: Liable,
     ) {
-        input.userId.validateObjectId("$field:userId")
         input.rate.validateRate("$field.rate")
     }
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/AddressCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/AddressCodec.kt
@@ -33,36 +33,34 @@ class AddressCodec : Codec<Address> {
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): Address {
-        var street: String? = null
-        var city: String? = null
-        var state: String? = null
-        var postalCode: String? = null
-        var country: String? = null
+        reader.readStartDocument()
+
+        val street = reader.readString("street")
+        val city = reader.readString("city")
+        val state = reader.readString("state")
+        val postalCode = reader.readString("postalCode")
+        val country = reader.readString("country")
+
         var unit: String? = null
         var rawInput: String? = null
         var formatted: String? = null
 
-        reader.readStartDocument()
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             when (reader.readName()) {
-                "street" -> street = reader.readString()
-                "city" -> city = reader.readString()
-                "state" -> state = reader.readString()
-                "postalCode" -> postalCode = reader.readString()
-                "country" -> country = reader.readString()
                 "unit" -> unit = reader.readString()
                 "rawInput" -> rawInput = reader.readString()
                 "formatted" -> formatted = reader.readString()
             }
         }
+
         reader.readEndDocument()
 
         return Address.builder()
-            .street(street!!)
-            .city(city!!)
-            .state(state!!)
-            .postalCode(postalCode!!)
-            .country(country!!)
+            .street(street)
+            .city(city)
+            .state(state)
+            .postalCode(postalCode)
+            .country(country)
             .unit(unit)
             .rawInput(rawInput)
             .formatted(formatted)

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/DiscountCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/DiscountCodec.kt
@@ -35,22 +35,24 @@ class DiscountCodec(private val monetaryAmountCodec: MonetaryAmountCodec) : Code
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): Discount {
-        var category: DiscountType? = null
+        reader.readStartDocument()
+
+        val category = DiscountType.from(reader.readString("category"))
+
         var value: MonetaryAmount? = null
         var rate: BigDecimal? = null
 
-        reader.readStartDocument()
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             when (reader.readName()) {
-                "category" -> category = DiscountType.from(reader.readString())
                 "value" -> value = monetaryAmountCodec.decode(reader, decoderContext)
                 "rate" -> rate = reader.readDecimal128().bigDecimalValue()
             }
         }
+
         reader.readEndDocument()
 
         return Discount.builder()
-            .category(category!!)
+            .category(category)
             .value(value)
             .rate(rate)
             .build()

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/FeeCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/FeeCodec.kt
@@ -34,14 +34,15 @@ class FeeCodec(private val monetaryAmountCodec: MonetaryAmountCodec) : Codec<Fee
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): Fee {
-        var name: String? = null
+        reader.readStartDocument()
+
+        val name = reader.readString("name")
+
         var value: MonetaryAmount? = null
         var rate: BigDecimal? = null
 
-        reader.readStartDocument()
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             when (reader.readName()) {
-                "name" -> name = reader.readString()
                 "value" -> value = monetaryAmountCodec.decode(reader, decoderContext)
                 "rate" -> rate = reader.readDecimal128().bigDecimalValue()
             }
@@ -49,7 +50,7 @@ class FeeCodec(private val monetaryAmountCodec: MonetaryAmountCodec) : Codec<Fee
         reader.readEndDocument()
 
         return Fee.builder()
-            .name(name!!)
+            .name(name)
             .value(value)
             .rate(rate)
             .build()

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/ItemCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/ItemCodec.kt
@@ -3,7 +3,6 @@ package com.quri.management.db.mongo.codecs
 import com.quri.client.model.Discount
 import com.quri.client.model.Item
 import com.quri.client.model.Liable
-import com.quri.client.model.MonetaryAmount
 import org.bson.BsonReader
 import org.bson.BsonType
 import org.bson.BsonWriter
@@ -31,14 +30,14 @@ class ItemCodec(
             writer.writeName("unitCost")
             monetaryAmountCodec.encode(writer, ma, encoderContext)
         }
-        value.liable?.let { list ->
+        value.liable.let { list ->
             writer.writeStartArray("liable")
             list.forEach { liable ->
                 liableCodec.encode(writer, liable, encoderContext)
             }
             writer.writeEndArray()
         }
-        value.discounts?.let { list ->
+        value.discounts.let { list ->
             writer.writeStartArray("discounts")
             list.forEach { discount ->
                 discountCodec.encode(writer, discount, encoderContext)
@@ -52,21 +51,17 @@ class ItemCodec(
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): Item {
-        var name: String? = null
-        var units: Int? = null
-        var unitCost: MonetaryAmount? = null
+        reader.readStartDocument()
+
+        val name = reader.readString("name")
+        val units = reader.readInt32("units")
+        val unitCost = monetaryAmountCodec.decode(reader, decoderContext)
+
         var liable: List<Liable>? = emptyList()
         var discounts: List<Discount>? = emptyList()
 
-        reader.readStartDocument()
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             when (reader.readName()) {
-                "name" -> name = reader.readString()
-
-                "units" -> units = reader.readInt32()
-
-                "unitCost" -> unitCost = monetaryAmountCodec.decode(reader, decoderContext)
-
                 "liable" -> {
                     val list = mutableListOf<Liable>()
                     reader.readStartArray()
@@ -91,9 +86,9 @@ class ItemCodec(
         reader.readEndDocument()
 
         return Item.builder()
-            .name(name!!)
-            .units(units!!)
-            .unitCost(unitCost!!)
+            .name(name)
+            .units(units)
+            .unitCost(unitCost)
             .liable(liable)
             .discounts(discounts)
             .build()

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/LiableCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/LiableCodec.kt
@@ -2,13 +2,11 @@ package com.quri.management.db.mongo.codecs
 
 import com.quri.client.model.Liable
 import org.bson.BsonReader
-import org.bson.BsonType
 import org.bson.BsonWriter
 import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.types.Decimal128
-import java.math.BigDecimal
 
 class LiableCodec : Codec<Liable> {
 
@@ -29,21 +27,16 @@ class LiableCodec : Codec<Liable> {
         reader: BsonReader,
         context: DecoderContext,
     ): Liable {
-        var userId: String? = null
-        var rate: BigDecimal? = null
-
         reader.readStartDocument()
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            when (reader.readName()) {
-                "userId" -> userId = reader.readString()
-                "rate" -> rate = reader.readDecimal128().bigDecimalValue()
-            }
-        }
+
+        val userId = reader.readString("userId")
+        val rate = reader.readDecimal128("rate").bigDecimalValue()
+
         reader.readEndDocument()
 
         return Liable.builder()
-            .userId(userId!!)
-            .rate(rate!!)
+            .userId(userId)
+            .rate(rate)
             .build()
     }
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/MonetaryAmountCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/MonetaryAmountCodec.kt
@@ -2,7 +2,6 @@ package com.quri.management.db.mongo.codecs
 
 import com.quri.client.model.MonetaryAmount
 import org.bson.BsonReader
-import org.bson.BsonType
 import org.bson.BsonWriter
 import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
@@ -28,21 +27,16 @@ class MonetaryAmountCodec : Codec<MonetaryAmount> {
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): MonetaryAmount {
-        var amount: java.math.BigDecimal? = null
-        var currency: String? = null
-
         reader.readStartDocument()
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            when (reader.readName()) {
-                "amount" -> amount = reader.readDecimal128().bigDecimalValue()
-                "currency" -> currency = reader.readString()
-            }
-        }
+
+        val amount = reader.readDecimal128("amount").bigDecimalValue()
+        val currency = reader.readString("currency")
+
         reader.readEndDocument()
 
         return MonetaryAmount.builder()
-            .amount(amount!!)
-            .currency(currency!!)
+            .amount(amount)
+            .currency(currency)
             .build()
     }
 }

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/MongoCodecConfig.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/MongoCodecConfig.kt
@@ -29,6 +29,7 @@ class MongoCodecConfig {
                 discountCodec,
                 FeeCodec(monetaryAmountCodec),
                 ItemCodec(monetaryAmountCodec, liableCodec, discountCodec),
+                liableCodec,
                 monetaryAmountCodec,
                 UserLocationCodec(),
             ),

--- a/src/main/kotlin/com/quri/management/db/mongo/codecs/UserLocationCodec.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/codecs/UserLocationCodec.kt
@@ -2,7 +2,6 @@ package com.quri.management.db.mongo.codecs
 
 import com.quri.client.model.UserLocation
 import org.bson.BsonReader
-import org.bson.BsonType
 import org.bson.BsonWriter
 import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
@@ -28,24 +27,18 @@ class UserLocationCodec : Codec<UserLocation> {
         reader: BsonReader,
         decoderContext: DecoderContext,
     ): UserLocation {
-        var city: String? = null
-        var state: String? = null
-        var country: String? = null
-
         reader.readStartDocument()
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            when (reader.readName()) {
-                "city" -> city = reader.readString()
-                "state" -> state = reader.readString()
-                "country" -> country = reader.readString()
-            }
-        }
+
+        val city = reader.readString("city")
+        val state = reader.readString("state")
+        val country = reader.readString("country")
+
         reader.readEndDocument()
 
         return UserLocation.builder()
-            .city(city!!)
-            .state(state!!)
-            .country(country!!)
+            .city(city)
+            .state(state)
+            .country(country)
             .build()
     }
 }

--- a/src/test/kotlin/com/quri/management/api/validation/model/ItemValidatorTest.kt
+++ b/src/test/kotlin/com/quri/management/api/validation/model/ItemValidatorTest.kt
@@ -125,26 +125,6 @@ class ItemValidatorTest :
 
                     validator.validate("field", item)
                 }
-
-                it("throws ValidationException when user ID is not valid") {
-                    val item = Item.builder()
-                        .name("Item")
-                        .units(1)
-                        .unitCost(ReceiptFixtures.aMonetaryAmount())
-                        .liable(
-                            listOf(
-                                Liable.builder()
-                                    .userId("fake-id")
-                                    .rate(BigDecimal("0.69"))
-                                    .build(),
-                            ),
-                        )
-                        .build()
-
-                    shouldThrow<ValidationException> {
-                        validator.validate("field", item)
-                    }
-                }
             }
         }
     })

--- a/src/test/kotlin/com/quri/management/api/validation/model/LiableValidatorTest.kt
+++ b/src/test/kotlin/com/quri/management/api/validation/model/LiableValidatorTest.kt
@@ -47,20 +47,6 @@ class LiableValidatorTest :
                 }
             }
 
-            context("when userId is not a valid ObjectId") {
-                it("throws ValidationException for invalid ObjectId") {
-                    shouldThrow<ValidationException> {
-                        validator.validate(
-                            "field",
-                            Liable.builder()
-                                .userId("test")
-                                .rate(BigDecimal("0.69"))
-                                .build(),
-                        )
-                    }
-                }
-            }
-
             context("when rate is out of range") {
                 it("throws ValidationException above one") {
                     shouldThrow<ValidationException> {

--- a/src/test/kotlin/com/quri/management/api/validation/receipt/ReceiptFieldsValidatorTest.kt
+++ b/src/test/kotlin/com/quri/management/api/validation/receipt/ReceiptFieldsValidatorTest.kt
@@ -204,7 +204,10 @@ class ReceiptFieldsValidatorTest :
 
             context("fees") {
                 it("passes for valid fee list") {
-                    validator.validate("field", fees = listOf(ReceiptFixtures.aFee()))
+                    validator.validate(
+                        "field",
+                        fees = listOf(ReceiptFixtures.aFlatFee(), ReceiptFixtures.aPercentageFee()),
+                    )
                 }
 
                 it("throws ValidationException for fee with neither value nor rate") {
@@ -221,7 +224,8 @@ class ReceiptFieldsValidatorTest :
                         validator.validate(
                             "field",
                             fees = listOf(
-                                ReceiptFixtures.aFee(),
+                                ReceiptFixtures.aFlatFee(),
+                                ReceiptFixtures.aPercentageFee(),
                                 Fee.builder().name("Service").build(),
                             ),
                         )

--- a/src/test/kotlin/com/quri/management/api/validation/receipt/UpdateReceiptValidatorTest.kt
+++ b/src/test/kotlin/com/quri/management/api/validation/receipt/UpdateReceiptValidatorTest.kt
@@ -52,8 +52,10 @@ class UpdateReceiptValidatorTest :
                         tax = BigDecimal("0.05"),
                         tip = BigDecimal("0.05"),
                         totalSavings = ReceiptFixtures.aMonetaryAmount(),
-                        fees = listOf(ReceiptFixtures.aFee()),
+                        fees = listOf(ReceiptFixtures.aFlatFee(), ReceiptFixtures.aFlatFee()),
+                        address = ReceiptFixtures.aValidAddress(),
                         photoId = "test photo id",
+                        urls = listOf("https://example.com"),
                     )
                     validator.validate("UpdateReceipt", input)
                 }

--- a/src/test/kotlin/com/quri/management/fixtures/models/ReceiptFixtures.kt
+++ b/src/test/kotlin/com/quri/management/fixtures/models/ReceiptFixtures.kt
@@ -4,6 +4,7 @@ import com.quri.client.model.Address
 import com.quri.client.model.CreateReceiptInput
 import com.quri.client.model.DeleteReceiptInput
 import com.quri.client.model.Discount
+import com.quri.client.model.DiscountType
 import com.quri.client.model.Fee
 import com.quri.client.model.GetReceiptInput
 import com.quri.client.model.Item
@@ -31,12 +32,57 @@ object ReceiptFixtures {
             .currency(currency)
             .build()
 
+    fun aLiable(
+        userId: String = DEFAULT_USER_ID,
+        rate: BigDecimal = BigDecimal("1.0"),
+    ): Liable =
+        Liable.builder()
+            .userId(userId)
+            .rate(rate)
+            .build()
+
+    fun anAmountDiscount(
+        category: DiscountType = DiscountType.PROMO,
+        value: MonetaryAmount = aMonetaryAmount(amount = BigDecimal("1.00")),
+    ): Discount =
+        Discount.builder()
+            .category(category)
+            .value(value)
+            .build()
+
+    fun aRateDiscount(
+        category: DiscountType = DiscountType.PROMO,
+        rate: BigDecimal = BigDecimal("0.1"),
+    ): Discount =
+        Discount.builder()
+            .category(category)
+            .rate(rate)
+            .build()
+
+    fun aFlatFee(
+        name: String = "Service Fee",
+        value: MonetaryAmount = aMonetaryAmount(),
+    ): Fee =
+        Fee.builder()
+            .name(name)
+            .value(value)
+            .build()
+
+    fun aPercentageFee(
+        name: String = "Service Fee",
+        rate: BigDecimal = BigDecimal("0.05"),
+    ): Fee =
+        Fee.builder()
+            .name(name)
+            .rate(rate)
+            .build()
+
     fun anItem(
         name: String = "Test Item",
         units: Int = 1,
         unitCost: MonetaryAmount = aMonetaryAmount(),
-        liable: List<Liable>? = emptyList(),
-        discounts: List<Discount>? = emptyList(),
+        liable: List<Liable>? = listOf(aLiable()),
+        discounts: List<Discount>? = listOf(anAmountDiscount(), aRateDiscount()),
     ): Item =
         Item.builder()
             .name(name)
@@ -46,15 +92,7 @@ object ReceiptFixtures {
             .discounts(discounts)
             .build()
 
-    fun aFee(
-        name: String = "Service Fee",
-        value: MonetaryAmount = aMonetaryAmount(),
-    ): Fee =
-        Fee.builder()
-            .name(name)
-            .value(value)
-            .build()
-
+    @Suppress("CyclomaticComplexMethod")
     fun aReceipt(
         id: String = DEFAULT_RECEIPT_ID,
         vendorName: String = "Test Vendor",
@@ -62,6 +100,13 @@ object ReceiptFixtures {
         occurredAt: Instant = Instant.parse("2024-01-01T00:00:00Z"),
         paymentMethod: PaymentMethod = PaymentMethod.CREDIT,
         subtotal: MonetaryAmount = aMonetaryAmount(),
+        tax: BigDecimal? = BigDecimal("0.06"),
+        tip: BigDecimal? = BigDecimal("0.15"),
+        totalSavings: MonetaryAmount? = aMonetaryAmount(amount = BigDecimal("2.00")),
+        fees: List<Fee>? = listOf(aFlatFee(), aPercentageFee()),
+        address: Address? = aValidAddress(),
+        photoId: String? = "photo-1",
+        urls: List<String>? = listOf("https://example.com/receipt.jpg"),
         createdAt: Instant = Instant.parse("2024-01-01T00:00:00Z"),
         createdBy: String = DEFAULT_USER_ID,
         updatedAt: Instant = Instant.parse("2024-01-01T00:00:00Z"),
@@ -74,10 +119,53 @@ object ReceiptFixtures {
             .occurredAt(occurredAt)
             .paymentMethod(paymentMethod)
             .subtotal(subtotal)
+            .apply { tax?.let { tax(it) } }
+            .apply { tip?.let { tip(it) } }
+            .apply { totalSavings?.let { totalSavings(it) } }
+            .apply { fees?.let { fees(it) } }
+            .apply { address?.let { address(it) } }
+            .apply { photoId?.let { photoId(it) } }
+            .apply { urls?.let { urls(it) } }
             .createdAt(createdAt)
             .createdBy(createdBy)
             .updatedAt(updatedAt)
             .updatedBy(updatedBy)
+            .build()
+
+    fun aValidAddress(
+        street: String = "123 Main Street",
+        city: String = "Arlington",
+        state: String = "VA",
+        postalCode: String = "20001",
+        country: String = "US",
+        unit: String? = "Apt 4B",
+        rawInput: String? = "123 main st apt 4b arlington va 20001",
+        formatted: String? = "123 Main Street, Apt 4B, Arlington, VA 20001, US",
+    ): Address =
+        Address.builder()
+            .street(street)
+            .city(city)
+            .state(state)
+            .postalCode(postalCode)
+            .country(country)
+            .apply { unit?.let { unit(it) } }
+            .apply { rawInput?.let { rawInput(it) } }
+            .apply { formatted?.let { formatted(it) } }
+            .build()
+
+    fun aMinimalAddress(
+        street: String = "123 Main Street",
+        city: String = "Arlington",
+        state: String = "VA",
+        postalCode: String = "20001",
+        country: String = "US",
+    ): Address =
+        Address.builder()
+            .street(street)
+            .city(city)
+            .state(state)
+            .postalCode(postalCode)
+            .country(country)
             .build()
 
     fun aCreateReceiptInput(
@@ -93,21 +181,6 @@ object ReceiptFixtures {
             .occurredAt(occurredAt)
             .paymentMethod(paymentMethod)
             .subtotal(subtotal)
-            .build()
-
-    fun aValidAddress(
-        street: String = "123 Main Street",
-        city: String = "Arlington",
-        state: String = "VA",
-        postalCode: String = "20001",
-        country: String = "US",
-    ): Address =
-        Address.builder()
-            .street(street)
-            .city(city)
-            .state(state)
-            .postalCode(postalCode)
-            .country(country)
             .build()
 
     fun aGetReceiptInput(id: String = DEFAULT_RECEIPT_ID): GetReceiptInput =


### PR DESCRIPTION
__What__

Refactored BSON codec `decode()` methods and test fixtures to improve coverage clarity. Removed `userId` ObjectId validation from `LiableValidator` and its tests after confirming `userId` is a string identifier, not a MongoDB ObjectId.

__Why__

Codecs with all-required fields (Liable, MonetaryAmount, UserLocation) used a while-loop/when pattern that introduced nullable vars and `!!` assertions even though every field is guaranteed present in the document. The while-loop was needed only for models with optional fields (Address, Discount, Fee, Item). Separating the two patterns eliminates unnecessary nullability, the `when (reader.readName())` partial-coverage gap, and makes the decode intent explicit — sequential read for guaranteed fields, while-loop for optional fields.

__How__

- __AddressCodec, DiscountCodec, FeeCodec__: Only the truly optional fields (`unit`/`rawInput`/`formatted`, `value`/`rate`) remain in the while-loop. Required fields (`street`/`city`/`state`/`postalCode`/`country`, `category`, `name`) read sequentially via named-overload `reader.read*(String)` calls, removing nullable vars and `!!`.
- __ItemCodec__: Required fields (`name`, `units`, `unitCost`) read sequentially; optional lists (`liable`, `discounts`) remain in the while-loop.
- __ReceiptFixtures__: Added distinct fixture methods (`aLiable`, `anAmountDiscount`, `aRateDiscount`, `aFlatFee`, `aPercentageFee`, `aMinimalAddress`) so call sites explicitly declare which variant they're building, replacing the single generic `aFee()` that could be misused.
- __ReceiptCollectionTest__: Added round-trip integration test exercising LiableCodec and DiscountCodec decode through a fresh fetch, pairing amount-only and rate-only Discount fixtures to confirm each optional-field branch is hit.
- __LiableValidator__: Removed `validateObjectId` check on `userId` — the field is a non-MongoDB string identifier, not an ObjectId.
