### PR TITLE
[REFACT]: use doc.id directly in collection create methods

### DIFF
--- a/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/BillCollection.kt
@@ -55,9 +55,8 @@ class BillCollection(private val dataStoreDatabase: MongoDatabase) {
         ownerId: String,
     ): Bill? {
         val doc = BillDocument.from(input, ownerId)
-        val result = collection.insertOne(doc)
-        val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
-        return doc.toApi(generatedId)
+        collection.insertOne(doc)
+        return doc.toApi(doc.id.toHexString())
     }
 
     /**

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ProfileCollection.kt
@@ -55,9 +55,8 @@ class ProfileCollection(dataStoreDatabase: MongoDatabase) {
         ownerId: String,
     ): Profile? {
         val doc = ProfileDocument.from(input, ownerId)
-        val result = collection.insertOne(doc)
-        val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
-        return doc.toApi(generatedId)
+        collection.insertOne(doc)
+        return doc.toApi(doc.id.toHexString())
     }
 
     /**

--- a/src/main/kotlin/com/quri/management/db/mongo/collections/ReceiptCollection.kt
+++ b/src/main/kotlin/com/quri/management/db/mongo/collections/ReceiptCollection.kt
@@ -55,9 +55,8 @@ class ReceiptCollection(dataStoreDatabase: MongoDatabase) {
         ownerId: String,
     ): Receipt? {
         val doc = ReceiptDocument.from(input, ownerId)
-        val result = collection.insertOne(doc)
-        val generatedId = result.insertedId?.asObjectId()?.value?.toString() ?: return null
-        return doc.toApi(generatedId)
+        collection.insertOne(doc)
+        return doc.toApi(doc.id.toHexString())
     }
 
     /**


### PR DESCRIPTION
__What__

Replaced `result.insertedId?.asObjectId()?.value?.toString() ?: return null` with `doc.id.toHexString()` in all three collection `create` methods.

__Why__

The `@BsonId` on each document already generates a unique `ObjectId` at construction time, so extracting the ID back from the MongoDB insert result is unnecessary. The original nullable chain produced multiple bytecode branches that coverage tools flagged as partially covered, despite the null path being unreachable.

__How__

- Discarded the `InsertOneResult` return value — `collection.insertOne(doc)` is called for its side effect only, since the ID we need is already on `doc.id`.
