### PR TITLE
[CI](workflows): add Gradle build/test pipeline and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+# Keeps GitHub Actions versions (actions/checkout, setup-java, etc.) current
+#
+# Scope is intentionally limited to github-actions. Gradle/Kotlin/Spring
+# dependency versions in libs.versions.toml are not managed here.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,75 @@
+---
+# Builds and tests QuriManagementService (Kotlin + Spring Boot + Gradle).
+#
+# QuriModels is consumed via a Gradle composite build (see settings.gradle.kts:
+# includeBuild("../QuriModels")), not as a published Maven artifact. That means
+# this workflow checks out both repos side by side so Gradle can substitute
+# `com.quri:quri-models` with QuriModels' current source at build time — no
+# publish step, no version pinning, always builds against latest QuriModels.
+#
+# Steps run in order: detekt (static analysis) -> unit tests -> integration
+# tests (Testcontainers + real Mongo via Docker) -> kover coverage gate (90%).
+name: Gradle Build & Test
+
+"on":
+  push:
+    branches: [ main, 'ci' ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout QuriManagementService
+        uses: actions/checkout@v7
+        with:
+          path: QuriManagementService
+
+      - name: Checkout QuriModels
+        uses: actions/checkout@v7
+        with:
+          repository: lizarazukevin/QuriModels
+          path: QuriModels
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Detekt
+        working-directory: QuriManagementService
+        run: ./gradlew detekt --no-daemon
+
+      - name: Unit tests
+        working-directory: QuriManagementService
+        run: ./gradlew test --no-daemon
+
+      - name: Integration tests
+        working-directory: QuriManagementService
+        run: ./gradlew integration --no-daemon
+
+      - name: Coverage verification
+        working-directory: QuriManagementService
+        run: ./gradlew koverVerify --no-daemon
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports
+          path: |
+            QuriManagementService/build/reports/tests/
+            QuriManagementService/build/reports/detekt/
+            QuriManagementService/build/reports/kover/
+          retention-days: 14


### PR DESCRIPTION
### What

Adds a GitHub Actions workflow for building and testing QuriManagementService (detekt → unit tests → integration tests → kover coverage gate), and a Dependabot config to keep GitHub Action versions current.

### Why

Without CI there is no automated safety net — no static analysis, no test execution, no coverage enforcement. Every PR to `main` should be validated before merge, and Action versions need automated bump tracking to avoid bitrot.

### How

- Composite build approach: checks out both QuriManagementService and QuriModels as siblings so the Gradle `includeBuild("../QuriModels")` in `settings.gradle.kts` resolves correctly without a publish step
- Step ordering enforces the dependency chain: detekt → unit tests → integration tests → `koverVerify` (90% min), with `shouldRunAfter("test")` on the integration task to prevent OOM from concurrent test containers
- Integration tests run inside the workflow via Testcontainers on `ubuntu-latest`, which ships with Docker — no separate service container or Docker step needed
- `cache-read-only: ${{ github.ref != 'refs/heads/main' }}` prevents PRs from poisoning the Gradle cache written by `main` branch runs
- Dependabot groups all GitHub Action updates into a single PR and limits to 2 open PRs to keep noise low; Gradle dependency updates intentionally excluded (managed via `libs.versions.toml`)
