### PR TITLE
build: increase Gradle daemon metaspace and enable parallel + caching

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,6 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+org.gradle.jvmargs=-Xmx1536m -XX:MaxMetaspaceSize=1g
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Default JVM args (512m heap / 384m metaspace) were insufficient for the composite build, causing the daemon to exit after every build:

  "Daemon will be stopped at the end of the build after running out of JVM Metaspace"

Bumps heap to 1536m and metaspace to 1g, and enables parallel execution and build caching to speed up composite builds across QuriManagementService and QuriModels.

> AKA more memory headroom for build/lint/test tools